### PR TITLE
URL Parameters

### DIFF
--- a/cypress/integration/authoring.test.ts
+++ b/cypress/integration/authoring.test.ts
@@ -1,0 +1,26 @@
+context("Test the authoring page", () => {
+  beforeEach(() => {
+    cy.visit("/?authoring", {
+      onBeforeLoad(win) {
+        cy.stub(win, "open").as("windowOpen");
+      }
+    });
+  });
+
+  describe("Generated URL", () => {
+    it("contains default parameters", () => {
+      cy.contains("Submit").click();
+
+      const topBarParam = encodeURIComponent(`"topBar":true`);
+      cy.get("@windowOpen").should("be.calledWithMatch", topBarParam);
+    });
+
+    it("contains updated parameters", () => {
+      cy.contains("Top Bar").click();
+      cy.contains("Submit").click();
+
+      const topBarParam = encodeURIComponent(`"topBar":false`);
+      cy.get("@windowOpen").should("be.calledWithMatch", topBarParam);
+    });
+  });
+});

--- a/cypress/integration/url-params.test.ts
+++ b/cypress/integration/url-params.test.ts
@@ -1,0 +1,20 @@
+context("Test URL parameters", () => {
+  describe("Top Bar", () => {
+    it("is visible by default", () => {
+      cy.visit("");
+      cy.get(".top-bar").should("exist");
+    });
+
+    it("is hidden when specified", () => {
+      const hideParams = encodeURIComponent(JSON.stringify({topBar: false}));
+      cy.visit(`/?${hideParams}`);
+      cy.get(".top-bar").should("not.exist");
+    });
+
+    it("is visible when specified", () => {
+      const showParams = encodeURIComponent(JSON.stringify({topBar: true}));
+      cy.visit(`/?${showParams}`);
+      cy.get(".top-bar").should("exist");
+    });
+  });
+});

--- a/cypress/integration/workspace.test.ts
+++ b/cypress/integration/workspace.test.ts
@@ -5,8 +5,8 @@ context("Test the overall app", () => {
 
   describe("Desktop functionalities", () => {
     it("renders with text", () => {
-      cy.get('.app-container').should('exist');
-      cy.get('.nav-and-content-container').should('exist');
+      cy.get(".app-container").should("exist");
+      cy.get(".nav-and-content-container").should("exist");
     });
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1591,6 +1591,11 @@
       "integrity": "sha512-403D4wN95Mtzt2EoQHARf5oe/jEPhzBOBNrunk+ydQGW8WmkQ/E8rViRAEB1qEt/vssfGfNVD6ujP4FVeegrLg==",
       "dev": true
     },
+    "@types/json-schema": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.1.tgz",
+      "integrity": "sha512-NVQEMviDWjuen3UW+mU1J6fZ0WhOfG1yRce/2OTcbaz+fgmTw2cahx6N2wh0Yl+a+hg2UZj/oElZmtULWyGIsA=="
+    },
     "@types/lodash": {
       "version": "4.14.116",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.116.tgz",
@@ -1618,8 +1623,7 @@
     "@types/prop-types": {
       "version": "15.5.6",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.5.6.tgz",
-      "integrity": "sha512-ZBFR7TROLVzCkswA3Fmqq+IIJt62/T7aY/Dmz+QkU7CaW2QFqAitCE8Ups7IzmGhcN1YWMBT4Qcoc07jU9hOJQ==",
-      "dev": true
+      "integrity": "sha512-ZBFR7TROLVzCkswA3Fmqq+IIJt62/T7aY/Dmz+QkU7CaW2QFqAitCE8Ups7IzmGhcN1YWMBT4Qcoc07jU9hOJQ=="
     },
     "@types/query-string": {
       "version": "6.1.0",
@@ -1631,7 +1635,6 @@
       "version": "16.4.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-16.4.14.tgz",
       "integrity": "sha512-Gh8irag2dbZ2K6vPn+S8+LNrULuG3zlCgJjVUrvuiUK7waw9d9CFk2A/tZFyGhcMDUyO7tznbx1ZasqlAGjHxA==",
-      "dev": true,
       "requires": {
         "@types/prop-types": "15.5.6",
         "csstype": "2.5.7"
@@ -1645,6 +1648,15 @@
       "requires": {
         "@types/node": "10.10.1",
         "@types/react": "16.4.14"
+      }
+    },
+    "@types/react-jsonschema-form": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@types/react-jsonschema-form/-/react-jsonschema-form-1.0.11.tgz",
+      "integrity": "sha512-n5yk3jQc2tTZA+d8l6ndFuTso1pymq57eVsHH8sKO3rAWLttuP4d5WjRpnjpOkzblwMMeSTIgP/1/HTY6vvHzw==",
+      "requires": {
+        "@types/json-schema": "*",
+        "@types/react": "*"
       }
     },
     "@types/sinon": {
@@ -2740,7 +2752,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "dev": true,
       "requires": {
         "core-js": "2.5.5",
         "regenerator-runtime": "0.11.1"
@@ -3867,8 +3878,7 @@
     "core-js": {
       "version": "2.5.5",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
-      "integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs=",
-      "dev": true
+      "integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -4052,8 +4062,7 @@
     "csstype": {
       "version": "2.5.7",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.5.7.tgz",
-      "integrity": "sha512-Nt5VDyOTIIV4/nRFswoCKps1R5CD1hkiyjBE9/thNaNZILLEviVw9yWQw15+O+CpNjQKB/uvdcxFFOrSflY3Yw==",
-      "dev": true
+      "integrity": "sha512-Nt5VDyOTIIV4/nRFswoCKps1R5CD1hkiyjBE9/thNaNZILLEviVw9yWQw15+O+CpNjQKB/uvdcxFFOrSflY3Yw=="
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -8688,6 +8697,11 @@
       "integrity": "sha1-0jM6NtnncXyK0vfKyv7HwytERmQ=",
       "dev": true
     },
+    "lodash.topath": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/lodash.topath/-/lodash.topath-4.5.2.tgz",
+      "integrity": "sha1-NhY1Hzu6YZlKCTGYlmC9AyVP0Ak="
+    },
     "log-symbols": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
@@ -10727,6 +10741,46 @@
       "integrity": "sha512-hSl7E6l25GTjNEZATqZIuWOgSnpXb3kD0DVCujmg46K5zLxsbiKaaT6VO9slkSBDPZfYs30lwfJwbOFOnoEnKQ==",
       "dev": true
     },
+    "react-jsonschema-form": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/react-jsonschema-form/-/react-jsonschema-form-1.0.5.tgz",
+      "integrity": "sha512-idnHVkOtRDspajpc4+IfLx9gLCnqJc5zZqEqUoc7SzjSVdCRAMaxT5Qr5lPdgzb8mRcJSXaXI+qwlVfKScrLBg==",
+      "requires": {
+        "ajv": "^5.2.3",
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.7",
+        "lodash.topath": "^4.5.2",
+        "prop-types": "^15.5.8"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "requires": {
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
+          }
+        },
+        "core-js": {
+          "version": "2.5.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+          "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+        },
+        "fast-deep-equal": {
+          "version": "1.1.0",
+          "resolved": "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+        },
+        "json-schema-traverse": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+        }
+      }
+    },
     "react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
@@ -11134,8 +11188,7 @@
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-      "dev": true
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
     "regenerator-transform": {
       "version": "0.13.3",

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "webpack-dev-server": "^3.1.9"
   },
   "dependencies": {
+    "@types/react-jsonschema-form": "^1.0.11",
     "immutable": "^3.8.2",
     "lodash": "^4.17.11",
     "mobx": "^5.5.0",
@@ -109,6 +110,7 @@
     "query-string": "^6.1.0",
     "react": "^16.5.0",
     "react-dom": "^16.5.0",
+    "react-jsonschema-form": "^1.0.5",
     "uuid": "^3.3.2",
     "wait-on": "^3.0.1"
   }

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -7,6 +7,7 @@ import "./app.sass";
 import { TopBarComponent } from "./top-bar";
 import { LeftNavPanelComponent } from "./left-nav-panel";
 import { MainContentComponent } from "./main-content";
+import { urlParams } from "../utilities/url-params";
 
 interface IProps extends IBaseProps {}
 interface IState {}
@@ -16,10 +17,9 @@ interface IState {}
 export class AppComponent extends BaseComponent<IProps, IState> {
 
   public render() {
-    const {ui} = this.stores;
     return (
       <div className="app-container">
-        <TopBarComponent />
+        {urlParams.topBar && <TopBarComponent />}
         <div className="nav-and-content-container">
           <LeftNavPanelComponent />
           <MainContentComponent />

--- a/src/components/authoring.tsx
+++ b/src/components/authoring.tsx
@@ -1,0 +1,35 @@
+import * as React from "react";
+import { BaseComponent, IBaseProps } from "./base";
+
+import "./app.sass";
+import Form, { ISubmitEvent } from "react-jsonschema-form";
+import { AppMode } from "../models/stores";
+import { QueryParams } from "../utilities/url-params";
+
+interface IProps extends IBaseProps {}
+interface IState {}
+
+export class AuthoringComponent extends BaseComponent<IProps, IState> {
+  public render() {
+    const onSubmit = (e: ISubmitEvent<QueryParams>) => {
+      const encodedParams = encodeURIComponent(JSON.stringify(e.formData));
+      window.open(`${location.origin}${location.pathname}?${encodedParams}`, "connected-bio-spaces");
+    };
+    return (
+      <div className="authoring">
+        <Form
+          schema={{
+            title: "Connected Bio Parameters",
+            type: "object",
+            properties: {
+              appMode: {type: "string", title: "App Mode", default: "dev", enum: [
+                "dev",
+                "authed"
+              ]}
+            }
+          }}
+          onSubmit={onSubmit} />
+      </div>
+    );
+  }
+}

--- a/src/components/authoring.tsx
+++ b/src/components/authoring.tsx
@@ -22,6 +22,7 @@ export class AuthoringComponent extends BaseComponent<IProps, IState> {
             title: "Connected Bio Parameters",
             type: "object",
             properties: {
+              topBar: {type: "boolean", title: "Show Top Bar?", default: true},
               appMode: {type: "string", title: "App Mode", default: "dev", enum: [
                 "dev",
                 "authed"

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,12 +6,21 @@ import { AppComponent } from "./components/app";
 import { createStores } from "./models/stores";
 
 import "./index.sass";
+import { urlParams } from "./utilities/url-params";
+import { AuthoringComponent } from "./components/authoring";
 
-const stores = createStores({ });
+const stores = createStores({ appMode: urlParams.appMode });
 
-ReactDOM.render(
-  <Provider stores={stores}>
-    <AppComponent />
-  </Provider>,
-  document.getElementById("app")
-);
+if (urlParams.authoring) {
+  ReactDOM.render((
+    <AuthoringComponent />
+    ), document.getElementById("app")
+  );
+} else {
+  ReactDOM.render(
+    <Provider stores={stores}>
+      <AppComponent />
+    </Provider>,
+    document.getElementById("app")
+  );
+}

--- a/src/utilities/url-params.ts
+++ b/src/utilities/url-params.ts
@@ -2,11 +2,13 @@ import { AppMode } from "../models/stores";
 
 export interface QueryParams {
   appMode?: AppMode;
+  topBar?: boolean;
   authoring?: boolean;
 }
 
 export const defaultUrlParams: QueryParams = {
   appMode: "dev",
+  topBar: true,
   authoring: false
 };
 

--- a/src/utilities/url-params.ts
+++ b/src/utilities/url-params.ts
@@ -1,17 +1,24 @@
-import { parse } from "query-string";
 import { AppMode } from "../models/stores";
 
 export interface QueryParams {
-  // appMode is "authed", "test" or "dev" with the default of dev
   appMode?: AppMode;
+  authoring?: boolean;
 }
 
-const params = parse(location.search);
-// allows use of ?demo for url
-params.demo = typeof params.demo !== "undefined";
-
-export const DefaultUrlParams: QueryParams = {
+export const defaultUrlParams: QueryParams = {
   appMode: "dev",
+  authoring: false
 };
+
+let params = defaultUrlParams;
+try {
+  const queryString = location.search.length > 1 ? decodeURIComponent(location.search.substring(1)) : "{}";
+  params = Object.assign(defaultUrlParams, JSON.parse(queryString));
+} catch (e) {
+  // allows use of ?authoring for url
+  if (location.search === "?authoring") {
+    params.authoring = true;
+  }
+}
 
 export const urlParams: QueryParams = params;


### PR DESCRIPTION
Here's a first pass at encoded JSON URL parameters. They're parsed and stored on load and can be imported anywhere. 

@pjanik and @scytacki had discussed using `react-jsonschema-form` to generate authoring pages that could validate inputs and return a JSON object. I gave it a try and it was pretty easy to use - only difficulty is that TypeScript complains unless the form schema is defined in-line because of some confusion over string literals. I also had some trouble keeping the form's data in React state without causing render loops, but fortunately I don't need to do that for now.