### PR TITLE
Chart improvements

### DIFF
--- a/src/components/charts/line-graph.tsx
+++ b/src/components/charts/line-graph.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { Scatter, ChartData } from "react-chartjs-2";
 import { observer } from "mobx-react";
 import { ChartDataModelType } from "../../models/spaces/charts/chart-data";
-import { ChartOptions, ChartAnimationOptions } from "chart.js";
+import { ChartOptions } from "chart.js";
 
 interface ILineProps {
   chartData: ChartDataModelType;
@@ -79,7 +79,6 @@ const lineData = (chartData: ChartDataModelType) => {
   return linePlotData;
 };
 
-const edgePadding = 0.1;
 @observer
 export class LineGraph extends React.Component<ILineProps> {
   constructor(props: ILineProps) {
@@ -99,8 +98,8 @@ export class LineGraph extends React.Component<ILineProps> {
         display: false,
         yAxes: [{
           ticks: {
-            min: minMaxValues.minA2 - (minMaxValues.minA2 * edgePadding),
-            max: minMaxValues.maxA2 + (minMaxValues.maxA2 * edgePadding)
+            min: minMaxValues.minA2,
+            max: minMaxValues.maxA2
           },
           scaleLabel: {
             display: true,
@@ -129,7 +128,7 @@ export class LineGraph extends React.Component<ILineProps> {
     );
 
     return (
-      <div>
+      <div className="line-chart-container">
         {graphs}
       </div>
     );

--- a/src/models/spaces/charts/chart-data-set.ts
+++ b/src/models/spaces/charts/chart-data-set.ts
@@ -68,7 +68,10 @@ export const ChartDataSetModel = types
     name: types.string,
     dataPoints: types.array(DataPoint),
     color: types.string,
-    maxPoints: types.maybe(types.number)
+    maxPoints: types.maybe(types.number),
+    fixedMin: types.maybe(types.number),
+    fixedMax: types.maybe(types.number),
+    expandOnly: false
   })
   .views(self => ({
     get dataTail() {
@@ -106,9 +109,16 @@ export const ChartDataSetModel = types
       }
     },
     get maxA2(): number | undefined {
-      if (!self.dataTail || self.dataTail.length === 0) {
+      if (self.fixedMax !== undefined) {
+        return self.fixedMax;
+      } else if (!self.dataTail || self.dataTail.length === 0) {
         return defaultMax;
+      }
+      else if (self.expandOnly) {
+        // always return max from all points so y axis only scales up, never down
+        return Math.max(...self.dataPoints.map(p => p.a2));
       } else {
+        // only return max of visible subset of data
         return Math.max(...self.dataTail.map(p => p.a2));
       }
     },
@@ -120,7 +130,9 @@ export const ChartDataSetModel = types
       }
     },
     get minA2(): number | undefined {
-      if (!self.dataTail || self.dataTail.length === 0) {
+      if (self.fixedMin !== undefined) {
+        return self.fixedMin;
+      } else if (!self.dataTail || self.dataTail.length === 0) {
         return defaultMin;
       } else {
         return Math.min(...self.dataTail.map(p => p.a2));

--- a/src/models/spaces/charts/chart-data-set.ts
+++ b/src/models/spaces/charts/chart-data-set.ts
@@ -68,9 +68,12 @@ export const ChartDataSetModel = types
     name: types.string,
     dataPoints: types.array(DataPoint),
     color: types.string,
-    maxPoints: types.maybe(types.number),
+    // If maxPoints is 0 we will always work with the entire data set
+    maxPoints: types.optional(types.number, -1),
     fixedMin: types.maybe(types.number),
     fixedMax: types.maybe(types.number),
+    // expandOnly is used for y-axis scaling. When requesting min/max point values,
+    // if this is set the a2 / y axis max returns the max of the full data set, not just the visiblePoints
     expandOnly: false,
     dataStartIdx: types.maybe(types.number)
   })
@@ -165,6 +168,8 @@ export const ChartDataSetModel = types
   }))
   .extend(self => {
     // actions
+    // fetching a subset of points is designed for scrubbing back and forth along a large set of data
+    // starting from a specified index. Set to -1 to remove the filter.
     function subsetPoints(idx: number) {
       self.dataStartIdx = idx;
     }
@@ -194,6 +199,7 @@ export const ChartDataSetModel = types
       self.dataPoints.splice(0, self.dataPoints.length);
     }
 
+    // used to filter data to a fixed number of points, or returns all points if set to -1
     function setMaxDataPoints(maxPoints: number) {
       self.maxPoints = maxPoints;
     }

--- a/src/models/spaces/charts/chart-data.test.ts
+++ b/src/models/spaces/charts/chart-data.test.ts
@@ -93,8 +93,6 @@ describe("chart data model", () => {
     expect(chart.dataSets[0].dataA1.length).toEqual(2);
     expect(chart.dataSets[0].dataA1[0]).toEqual(50);
     expect(chart.dataSets[0].dataA2[0]).toEqual(70);
-
-    // try getting a point from an index beyond the subset length
     expect(chart.dataSets[0].dataA1[2]).toBeUndefined;
   });
 });

--- a/src/models/spaces/charts/chart-data.test.ts
+++ b/src/models/spaces/charts/chart-data.test.ts
@@ -81,4 +81,20 @@ describe("chart data model", () => {
     expect(chart.dataSets[1].dataAsXY[1]).toEqual({ x: 20, y: 15 });
 
   });
+
+  it("can retrieve a subset of data", () => {
+    chart.dataSets[0].addDataPoint(65, 75, "delta");
+    chart.dataSets[0].addDataPoint(70, 85, "echo");
+    chart.dataSets[0].addDataPoint(75, 80, "foxtrot");
+
+    chart.setDataSetSubset(2, 2);
+
+    expect(chart.dataSets[0].dataPoints.length).toEqual(6);
+    expect(chart.dataSets[0].dataA1.length).toEqual(2);
+    expect(chart.dataSets[0].dataA1[0]).toEqual(50);
+    expect(chart.dataSets[0].dataA2[0]).toEqual(70);
+
+    // try getting a point from an index beyond the subset length
+    expect(chart.dataSets[0].dataA1[2]).toBeUndefined;
+  });
 });

--- a/src/models/spaces/charts/chart-data.ts
+++ b/src/models/spaces/charts/chart-data.ts
@@ -42,10 +42,24 @@ export const ChartDataModel = types
     function addDataSet(dataSet: ChartDataSetModelType) {
       self.dataSets.push(dataSet);
     }
+    function setDataSetSubset(idx: number, maxPoints: number) {
+      self.dataSets.forEach(d => {
+        d.subsetPoints(idx);
+        d.setMaxDataPoints(maxPoints);
+      });
+    }
+    function allData() {
+      self.dataSets.forEach(d => {
+        d.subsetPoints(-1);
+        d.setMaxDataPoints(-1);
+      });
+    }
 
     return {
       actions: {
-        addDataSet
+        allData,
+        addDataSet,
+        setDataSetSubset
       }
     };
   });

--- a/src/models/spaces/charts/chart-data.ts
+++ b/src/models/spaces/charts/chart-data.ts
@@ -42,12 +42,17 @@ export const ChartDataModel = types
     function addDataSet(dataSet: ChartDataSetModelType) {
       self.dataSets.push(dataSet);
     }
+    // If we want to scrub back and forth along a timeline of data points, but still need
+    // to limit our data point quantity for performance, pass a start index and
+    // the number of required points to filter the data
     function setDataSetSubset(idx: number, maxPoints: number) {
       self.dataSets.forEach(d => {
         d.subsetPoints(idx);
         d.setMaxDataPoints(maxPoints);
       });
     }
+    // To fetch all data from all datasets, remove any subset index points and set the max number of points to -1
+    // to ensure all data is returned unfiltered
     function allData() {
       self.dataSets.forEach(d => {
         d.subsetPoints(-1);

--- a/src/models/spaces/populations/mouse-model/mouse-populations-model.ts
+++ b/src/models/spaces/populations/mouse-model/mouse-populations-model.ts
@@ -11,13 +11,17 @@ const chartData = {
       name: "White mice",
       dataPoints: [],
       color: "#f4ce83",
-      maxPoints: 100
+      maxPoints: 100,
+      fixedMin: 0,
+      expandOnly: true
     },
     {
       name: "Brown mice",
       dataPoints: [],
       color: "#795423",
-      maxPoints: 100
+      maxPoints: 100,
+      fixedMin: 0,
+      expandOnly: true
     }
   ]
  };


### PR DESCRIPTION
This is a small PR to ensure we always retain all data from a data set, and improves handling of scaling on charts with some additional optional parameters to datasets:
fixedMin: can set to 0 to always start Y at 0
fixedMax: can set to a known quantity (i.e. 100) to set a constant scale
expandOnly: not compatible with fixedMax, which would override this value, this will ensure that scrolling horizontal line charts don't constantly rescale the upper bounds of the y axis