### PR TITLE
Multiple Cell Views

### DIFF
--- a/src/components/spaces/cell-zoom-space.tsx
+++ b/src/components/spaces/cell-zoom-space.tsx
@@ -17,18 +17,20 @@ export class CellZoomSpaceComponent extends BaseComponent<IProps, IState> {
     const {cellZoom} = this.stores;
     const graphTitle = "Graph";
 
-    const cellGraphPanel1 = <Chart title="Chart Test" chartData={cellZoom.currentData} chartType={"horizontalBar"} />;
+    const cellGraphPanel1 = <Chart title="Chart Test" chartData={cellZoom.rows[0].currentData}
+      chartType={"horizontalBar"} />;
     const cellZoomComponent1 = <TwoUpDisplayComponent
       leftTitle="Investigate: Cell"
-      leftPanel={<OrganelleWrapper elementName="organelle-wrapper-1" />}
+      leftPanel={<OrganelleWrapper elementName="organelle-wrapper-1" rowIndex={0}/>}
       rightTitle={graphTitle}
       rightPanel={cellGraphPanel1}
     />;
 
-    const cellGraphPanel2 = <Chart title="Chart Test" chartData={cellZoom.currentData} chartType={"horizontalBar"} />;
+    const cellGraphPanel2 = <Chart title="Chart Test" chartData={cellZoom.rows[1].currentData}
+      chartType={"horizontalBar"} />;
     const cellZoomComponent2 = <TwoUpDisplayComponent
       leftTitle="Investigate: Cell"
-      leftPanel={<OrganelleWrapper elementName="organelle-wrapper-2" />}
+      leftPanel={<OrganelleWrapper elementName="organelle-wrapper-2" rowIndex={1}/>}
       rightTitle={graphTitle}
       rightPanel={cellGraphPanel2}
     />;

--- a/src/components/spaces/cell-zoom/OrganelleWrapper.tsx
+++ b/src/components/spaces/cell-zoom/OrganelleWrapper.tsx
@@ -90,10 +90,9 @@ export class OrganelleWrapper extends BaseComponent<OrganelleWrapperProps, Organ
   }
 
   public componentDidMount() {
-    // const box = appStore.boxes.get(this.props.boxId);
-    // const view = box.viewType;
-    // const {organism} = box;
-    // const {modelProperties} = organism;
+    const { cellZoom } = this.stores;
+    const row = cellZoom.rows[this.props.rowIndex];
+    const { modelProperties } = row.organism as any;
     const modelDef: any = Cell;
 
     modelDef.container = {
@@ -102,15 +101,6 @@ export class OrganelleWrapper extends BaseComponent<OrganelleWrapperProps, Organ
       height: MODEL_HEIGHT
     };
 
-    const modelProperties: any = {
-      albino: false,
-      working_tyr1: false,
-      working_myosin_5a: true,
-      open_gates: false,
-      eumelanin: 50,
-      hormone_spawn_period: 40,
-      working_receptor: true
-    };
     modelDef.properties = modelProperties;
 
     createModel(modelDef).then((m: any) => {
@@ -296,32 +286,18 @@ export class OrganelleWrapper extends BaseComponent<OrganelleWrapperProps, Organ
     });
 
     model.on("model.step", () => {
-      // const organism: IOrganism = appStore.getBoxOrganism(this.props.boxId);
-      // let percentLightness = organism.lightness;
-      let percentLightness = .2;
-
-      if (percentLightness <= 0.19) {
-        percentLightness = 0;
-      } else if (percentLightness < 0.39) {
-        percentLightness = 0.2;
-      } else if (percentLightness < 0.59) {
-        percentLightness = 0.4;
-      } else if (percentLightness < 0.79) {
-        percentLightness = 0.6;
-      } else if (percentLightness < 0.99) {
-        percentLightness = 0.8;
-      } else {
-        percentLightness = 1;
-      }
+      const { cellZoom } = this.stores;
+      const { rowIndex } = this.props;
+      const { organism } = cellZoom.rows[rowIndex];
+      const percentDarkness = organism.getPercentDarkness();
 
       // go from lightest to darkest in HSL space, which provides the best gradual transition
 
       // lightest brown: rgb(244, 212, 141) : hsl(41°, 82%, 75%)
       // darkest brown:  rgb(124, 81, 21)   : hsl(35°, 71%, 28%)
-
       const light = [41, 82, 75];
       const dark = [35, 71, 28];
-      const color = dark.map( (c, i) => Math.round(c + (light[i] - c) * percentLightness) );
+      const color = light.map( (c, i) => Math.round(c + (dark[i] - c) * (percentDarkness / 100)) );
       const colorStr = `hsl(${color[0]},${color[1]}%,${color[2]}%)`;
 
       const cellFill = model.view.getModelSvgObjectById("cellshape_0_Layer0_0_FILL");

--- a/src/components/spaces/cell-zoom/OrganelleWrapper.tsx
+++ b/src/components/spaces/cell-zoom/OrganelleWrapper.tsx
@@ -7,13 +7,15 @@ import { observer, inject } from "mobx-react";
 // import { rootStore, Mode } from "../stores/RootStore";
 import { createModel } from "organelle";
 import * as Cell from "./cell-models/cell.json";
-import { OrganelleType, ModeType, kOrganelleInfo } from "../../../models/spaces/cell-zoom/cell-zoom";
+import { kOrganelleInfo } from "../../../models/spaces/cell-zoom/cell-zoom";
 import { BaseComponent } from "../../base";
 // import { SubstanceType } from "../models/Substance";
 import "./OrganelleWrapper.sass";
+import { OrganelleType, ModeType } from "../../../models/spaces/cell-zoom/cell-zoom-row.js";
 
 interface OrganelleWrapperProps {
   elementName: string;
+  rowIndex: number;
 }
 
 interface OrganelleWrapperState {
@@ -153,7 +155,7 @@ export class OrganelleWrapper extends BaseComponent<OrganelleWrapperProps, Organ
 
   public organelleClick(organelleType: OrganelleType, location: {x: number, y: number}) {
     const { cellZoom } = this.stores;
-    cellZoom.setActiveAssay(organelleType);
+    cellZoom.rows[this.props.rowIndex].setActiveAssay(organelleType);
     // if (rootStore.mode === Mode.Assay) {
     //   const organelleInfo = OrganelleRef.create({
     //     organism,
@@ -227,7 +229,7 @@ export class OrganelleWrapper extends BaseComponent<OrganelleWrapperProps, Organ
     const {cellZoom} = this.stores;
     // const hoverLabel = appStore.mysteryLabels ?
     //   mysteryOrganelleNames[this.state.hoveredOrganelle] : this.state.hoveredOrganelle;
-    const {hoveredOrganelle} = cellZoom;
+    const hoveredOrganelle = cellZoom.rows[this.props.rowIndex].hoveredOrganelle;
     const hoverLabel = hoveredOrganelle ? kOrganelleInfo[hoveredOrganelle].displayName : undefined;
     const hoverDiv = hoverLabel
       ? (
@@ -335,7 +337,7 @@ export class OrganelleWrapper extends BaseComponent<OrganelleWrapperProps, Organ
       const {cellZoom} = this.stores;
       const hoveredOrganelle = this.getOrganelleFromMouseEvent(evt);
       if (hoveredOrganelle) {
-        cellZoom.setHoveredOrganelle(hoveredOrganelle);
+        cellZoom.rows[this.props.rowIndex].setHoveredOrganelle(hoveredOrganelle);
       }
     });
 
@@ -367,7 +369,7 @@ export class OrganelleWrapper extends BaseComponent<OrganelleWrapperProps, Organ
       .filter(organelle => {
         const organelleInfo = this.organelleSelectorInfo[organelle];
         const visibleModes = organelleInfo.visibleModes;
-        return !visibleModes || visibleModes.indexOf(cellZoom.mode) > -1;
+        return !visibleModes || visibleModes.indexOf(cellZoom.rows[this.props.rowIndex].mode) > -1;
       });
     return possibleTargets.find((t) => {
       return evt.target._organelle.matches({selector: this.organelleSelectorInfo[t].selector});

--- a/src/components/spaces/cell-zoom/cell-mouse.ts
+++ b/src/components/spaces/cell-zoom/cell-mouse.ts
@@ -1,9 +1,12 @@
 import { types, Instance } from "mobx-state-tree";
 import { MouseColor } from "../../../models/mouse";
-import { SubstanceType, OrganelleType, kOrganelleInfo } from "../../../models/spaces/cell-zoom/cell-zoom";
+import { SubstanceType, kOrganelleInfo } from "../../../models/spaces/cell-zoom/cell-zoom";
+import { v4 as uuid } from "uuid";
+import { OrganelleType } from "../../../models/spaces/cell-zoom/cell-zoom-row";
 
 export const CellMouseModel = types
-  .model("Populations", {
+  .model("CellMouse", {
+    id: types.optional(types.identifier, () => uuid()),
     baseColor: MouseColor
   })
   .views(self => ({

--- a/src/components/spaces/cell-zoom/cell-mouse.ts
+++ b/src/components/spaces/cell-zoom/cell-mouse.ts
@@ -9,11 +9,33 @@ export const CellMouseModel = types
     id: types.optional(types.identifier, () => uuid()),
     baseColor: MouseColor
   })
-  .views(self => ({
-    getSubstanceValue(organelle: OrganelleType, substance: SubstanceType) {
+  .views(self => {
+    function getSubstanceValue(organelle: OrganelleType, substance: SubstanceType) {
       const substanceValues = kOrganelleInfo[organelle].substances[substance];
       return substanceValues ? substanceValues[self.baseColor] : 0;
     }
-  }));
+
+    function getPercentDarkness() {
+      const eumelaninLevel = getSubstanceValue("melanosome", "eumelanin");
+      return Math.max(0, Math.min(1, eumelaninLevel / 500)) * 100;
+    }
+
+    return {
+      getSubstanceValue,
+      getPercentDarkness,
+      get modelProperties() {
+        const workingReceptor = self.baseColor !== "white";
+        return {
+          albino: false,
+          working_tyr1: false,
+          working_myosin_5a: true,
+          open_gates: false,
+          eumelanin: getPercentDarkness(),
+          hormone_spawn_period: 40,
+          working_receptor: workingReceptor
+        };
+      }
+    };
+  });
 
 export type CellMouseModelType = Instance<typeof CellMouseModel>;

--- a/src/models/spaces/cell-zoom/cell-zoom-row.ts
+++ b/src/models/spaces/cell-zoom/cell-zoom-row.ts
@@ -1,0 +1,71 @@
+import { types, Instance } from "mobx-state-tree";
+import { ChartDataModelType, ChartDataModel } from "../charts/chart-data";
+import { DataPoint, ChartDataSetModel, ChartColors, DataPointType } from "../charts/chart-data-set";
+import { CellMouseModel } from "../../../components/spaces/cell-zoom/cell-mouse";
+import { kSubstanceNames } from "./cell-zoom";
+
+export const Organelle = types.enumeration("type", [
+  "nucleus",
+  "cytoplasm",
+  "golgi",
+  "extracellular",
+  "melanosome",
+  "receptor",
+  "gate",
+  "nearbyCell"
+]);
+export type OrganelleType = typeof Organelle.Type;
+
+export const Mode = types.enumeration("type", ["add", "subtract", "assay", "normal"]);
+export type ModeType = typeof Mode.Type;
+
+export const CellZoomRowModel = types
+  .model("CellZoomRow", {
+    organism: types.reference(CellMouseModel),
+    hoveredOrganelle: types.maybe(Organelle),
+    mode: types.optional(Mode, "normal"),
+    assayedOrganelle: types.maybe(Organelle)
+  })
+  .views(self => ({
+    get currentData(): ChartDataModelType {
+      const chartDataSets = [];
+      const points: DataPointType[] = [];
+      const organelle = self.assayedOrganelle;
+      if (organelle) {
+        kSubstanceNames.forEach((substance) => {
+          const substanceValue = self.organism.getSubstanceValue(organelle, substance);
+          if (substanceValue > 0) {
+            points.push(DataPoint.create({ a1: substanceValue, a2: 0, label: substance }));
+          }
+        });
+      }
+
+      chartDataSets.push(ChartDataSetModel.create({
+        name: "Sample Dataset1",
+        dataPoints: points,
+        color: ChartColors[0].hex, // all bars will be this color
+        // alternatively, use a specified array of specific colors for each bar:
+        // pointColors: ["#00ff00", "#ff0000"]
+        // if no color and no pointColors are specified, each bar will take on a color from ChartColors
+        maxPoints: 100
+      }));
+
+      const chart = ChartDataModel.create({
+        name: "Samples",
+        dataSets: chartDataSets
+      });
+      return chart;
+    }
+  }))
+  .actions((self) => {
+    return {
+      setHoveredOrganelle(organelle: OrganelleType) {
+        self.hoveredOrganelle = organelle;
+      },
+      setActiveAssay(organelle: OrganelleType) {
+        self.assayedOrganelle = organelle;
+      }
+    };
+  });
+
+export type CellZoomRowModelType = Instance<typeof CellZoomRowModel>;

--- a/src/models/spaces/cell-zoom/cell-zoom.ts
+++ b/src/models/spaces/cell-zoom/cell-zoom.ts
@@ -1,20 +1,7 @@
 import { types, Instance } from "mobx-state-tree";
-import { ChartDataModelType, ChartDataModel } from "../charts/chart-data";
-import { DataPoint, ChartDataSetModel, ChartColors, DataPointType } from "../charts/chart-data-set";
 import { ColorType } from "../../mouse";
 import { CellMouseModel } from "../../../components/spaces/cell-zoom/cell-mouse";
-
-export const Organelle = types.enumeration("type", [
-  "nucleus",
-  "cytoplasm",
-  "golgi",
-  "extracellular",
-  "melanosome",
-  "receptor",
-  "gate",
-  "nearbyCell"
-]);
-export type OrganelleType = typeof Organelle.Type;
+import { CellZoomRowModel, OrganelleType } from "./cell-zoom-row";
 
 export const kSubstanceNames = [
   "pheomelanin",
@@ -93,56 +80,10 @@ export const kOrganelleInfo: OrganelleInfo = {
   },
 };
 
-export const Mode = types.enumeration("type", ["add", "subtract", "assay", "normal"]);
-export type ModeType = typeof Mode.Type;
-
 export const CellZoomModel = types
-  .model("Populations", {
-    organism: CellMouseModel,
-    hoveredOrganelle: types.maybe(Organelle),
-    mode: types.optional(Mode, "normal"),
-    assayedOrganelle: types.maybe(Organelle)
-  })
-  .views(self => ({
-    get currentData(): ChartDataModelType {
-      const chartDataSets = [];
-      const points: DataPointType[] = [];
-      const organelle = self.assayedOrganelle;
-      if (organelle) {
-        kSubstanceNames.forEach((substance) => {
-          const substanceValue = self.organism.getSubstanceValue(organelle, substance);
-          if (substanceValue > 0) {
-            points.push(DataPoint.create({ a1: substanceValue, a2: 0, label: substance }));
-          }
-        });
-      }
-
-      chartDataSets.push(ChartDataSetModel.create({
-        name: "Sample Dataset1",
-        dataPoints: points,
-        color: ChartColors[0].hex, // all bars will be this color
-        // alternatively, use a specified array of specific colors for each bar:
-        // pointColors: ["#00ff00", "#ff0000"]
-        // if no color and no pointColors are specified, each bar will take on a color from ChartColors
-        maxPoints: 100
-      }));
-
-      const chart = ChartDataModel.create({
-        name: "Samples",
-        dataSets: chartDataSets
-      });
-      return chart;
-    }
-  }))
-  .actions((self) => {
-    return {
-      setHoveredOrganelle(organelle: OrganelleType) {
-        self.hoveredOrganelle = organelle;
-      },
-      setActiveAssay(organelle: OrganelleType) {
-        self.assayedOrganelle = organelle;
-      }
-    };
+  .model("CellZoom", {
+    organisms: types.map(CellMouseModel),
+    rows: types.array(CellZoomRowModel)
   });
 
 export type CellZoomModelType = Instance<typeof CellZoomModel>;

--- a/src/models/stores.ts
+++ b/src/models/stores.ts
@@ -4,6 +4,7 @@ import { BackpackModel, BackpackModelType } from "./backpack";
 import { flatten } from "flat";
 import { CellZoomModel, CellZoomModelType } from "./spaces/cell-zoom/cell-zoom";
 import { CellMouseModel } from "../components/spaces/cell-zoom/cell-mouse";
+import { CellZoomRowModel } from "./spaces/cell-zoom/cell-zoom-row";
 
 export type Curriculum = "mouse";
 
@@ -30,6 +31,15 @@ export function createStores(params: ICreateStores, authoring: any): IStores {
       createPopulationsModel(authoring.curriculum, flatten(authoring.populations)),
     backpack: params && params.backpack || BackpackModel.create({}),
     cellZoom: params && params.cellZoom
-      || CellZoomModel.create({ organism: CellMouseModel.create({baseColor: "brown"}) })
+      || CellZoomModel.create({
+           organisms: {
+            one: CellMouseModel.create({ id: "one", baseColor: "brown" }),
+            two: CellMouseModel.create({ id: "two", baseColor: "white" })
+          },
+          rows: [
+            CellZoomRowModel.create({organism: "one"}),
+            CellZoomRowModel.create({organism: "two"}),
+          ]
+         })
   };
 }


### PR DESCRIPTION
Per our discussion today, I'm starting on click-to-add mice to the cell view, starting with the ability to show multiple mice at a time. Let me know what you think of the updated state, which looks something like this:

The `CellZoom` model now contains a map of "cell mice" and an array of `CellZoomRow`s. Each row references a mouse from the map of mice - this way we can synchronize updates across views more easily. Most of the state that was previously tracked in the `CellZoom` model (e.g. hovered organelle, active assays) are now stored per-row instead.

I also quickly added cell color so you can see that the cell views are rendering different organisms.