### PR TITLE
Bar chart colors

### DIFF
--- a/src/components/charts/bar-chart.tsx
+++ b/src/components/charts/bar-chart.tsx
@@ -55,15 +55,7 @@ const defaultOptions: ChartOptions = {
 const barDatasetDefaults: ChartData<any> = {
   label: "",
   fill: false,
-  pointBackgroundColor: "#fff",
-  pointBorderWidth: 1,
-  pointHoverRadius: 5,
-  pointHoverBorderWidth: 2,
-  pointRadius: 1,
-  pointHitRadius: 10,
   data: [0],
-  backgroundColor: ChartColors.map(c => hexToRGBValue(c.hex, 0.4)),
-  borderColor: ChartColors.map(c => hexToRGBValue(c.hex, 1.0)),
   borderWidth: 2
 };
 
@@ -74,16 +66,21 @@ const barData = (chartData: ChartDataModelType) => {
       label: d.name,
       data: d.dataA1,
     });
+    const seriesOpacity = d.backgroundOpacity ? d.backgroundOpacity : 0.4;
     if (d.color) {
       // One color for all bars
-      dset.backgroundColor = hexToRGBValue(d.color, 0.4);
+      dset.backgroundColor = hexToRGBValue(d.color, seriesOpacity);
       dset.borderColor = hexToRGBValue(d.color, 1.0);
     } else if (d.pointColors) {
       // If we have specified point colors, use those first to color each bar,
       // then if we run out of defined colors we fall back to the defaults
       const colors = d.pointColors.concat(ChartColors.map(c => c.hex));
-      dset.backgroundColor = colors.map(c => hexToRGBValue(c, 0.4));
+      dset.backgroundColor = colors.map(c => hexToRGBValue(c, seriesOpacity));
       dset.borderColor = colors.map(c => hexToRGBValue(c, 1.0));
+    } else {
+      // Default to predefined colors
+      dset.backgroundColor = ChartColors.map(c => hexToRGBValue(c.hex, seriesOpacity));
+      dset.borderColor = ChartColors.map(c => hexToRGBValue(c.hex, 1.0));
     }
     barDatasets.push(dset);
   }

--- a/src/components/charts/bar-chart.tsx
+++ b/src/components/charts/bar-chart.tsx
@@ -3,6 +3,8 @@ import { observer } from "mobx-react";
 import { HorizontalBar, Bar, ChartData } from "react-chartjs-2";
 import { ChartDataModelType } from "../../models/spaces/charts/chart-data";
 import { ChartOptions, ChartType } from "chart.js";
+import { ChartColors } from "../../models/spaces/charts/chart-data-set";
+import { hexToRGBValue } from "../../utilities/color-utils";
 
 interface IBarProps {
   chartData: ChartDataModelType;
@@ -59,7 +61,9 @@ const barDatasetDefaults: ChartData<any> = {
   pointHoverBorderWidth: 2,
   pointRadius: 1,
   pointHitRadius: 10,
-  data: [0]
+  data: [0],
+  backgroundColor: ChartColors.map(c => hexToRGBValue(c.hex, 0.4)),
+  borderColor: ChartColors.map(c => hexToRGBValue(c.hex, 1.0))
 };
 
 const barData = (chartData: ChartDataModelType) => {
@@ -67,10 +71,7 @@ const barData = (chartData: ChartDataModelType) => {
   for (const d of chartData.dataSets) {
     const dset = Object.assign({}, barDatasetDefaults, {
       label: d.name,
-      data: d.dataA1,
-      backgroundColor: `rgba(${d.colorRGB},0.4)`,
-      pointBorderColor: `rgba(${d.colorRGB},1)`,
-      pointHoverBackgroundColor: `rgba(${d.colorRGB},1)`
+      data: d.dataA1
     });
     barDatasets.push(dset);
   }

--- a/src/components/charts/bar-chart.tsx
+++ b/src/components/charts/bar-chart.tsx
@@ -75,8 +75,15 @@ const barData = (chartData: ChartDataModelType) => {
       data: d.dataA1,
     });
     if (d.color) {
+      // One color for all bars
       dset.backgroundColor = hexToRGBValue(d.color, 0.4);
       dset.borderColor = hexToRGBValue(d.color, 1.0);
+    } else if (d.pointColors) {
+      // If we have specified point colors, use those first to color each bar,
+      // then if we run out of defined colors we fall back to the defaults
+      const colors = d.pointColors.concat(ChartColors.map(c => c.hex));
+      dset.backgroundColor = colors.map(c => hexToRGBValue(c, 0.4));
+      dset.borderColor = colors.map(c => hexToRGBValue(c, 1.0));
     }
     barDatasets.push(dset);
   }

--- a/src/components/charts/bar-chart.tsx
+++ b/src/components/charts/bar-chart.tsx
@@ -63,7 +63,8 @@ const barDatasetDefaults: ChartData<any> = {
   pointHitRadius: 10,
   data: [0],
   backgroundColor: ChartColors.map(c => hexToRGBValue(c.hex, 0.4)),
-  borderColor: ChartColors.map(c => hexToRGBValue(c.hex, 1.0))
+  borderColor: ChartColors.map(c => hexToRGBValue(c.hex, 1.0)),
+  borderWidth: 2
 };
 
 const barData = (chartData: ChartDataModelType) => {
@@ -71,8 +72,12 @@ const barData = (chartData: ChartDataModelType) => {
   for (const d of chartData.dataSets) {
     const dset = Object.assign({}, barDatasetDefaults, {
       label: d.name,
-      data: d.dataA1
+      data: d.dataA1,
     });
+    if (d.color) {
+      dset.backgroundColor = hexToRGBValue(d.color, 0.4);
+      dset.borderColor = hexToRGBValue(d.color, 1.0);
+    }
     barDatasets.push(dset);
   }
 

--- a/src/components/charts/chart-test.tsx
+++ b/src/components/charts/chart-test.tsx
@@ -20,6 +20,7 @@ export class ChartTest extends BaseComponent<IProps, IState> {
     chartDataSets.push(ChartDataSetModel.create({
       name: "Sample Dataset1",
       dataPoints: this.addTestDataPoints(),
+      backgroundOpacity: 0.9,
       // color: ChartColors[3].hex,
       // pointColors: ["#00ff00", "#ff0000", "#0000ff"],
       maxPoints: 100
@@ -27,8 +28,9 @@ export class ChartTest extends BaseComponent<IProps, IState> {
     chartDataSets.push(ChartDataSetModel.create({
       name: "Sample Dataset2",
       dataPoints: this.addTestDataPoints(),
-      color: "#00ffcc",
-      pointColors: ["#00ff00", "#ff0000", "#0000ff"],
+      // color: "#00ffcc",
+      // pointColors: ["#00ff00", "#ff0000", "#0000ff"],
+      backgroundOpacity: 0.3,
       maxPoints: 100
     }));
     const chartData: ChartDataModelType = ChartDataModel.create({

--- a/src/components/charts/chart-test.tsx
+++ b/src/components/charts/chart-test.tsx
@@ -20,13 +20,15 @@ export class ChartTest extends BaseComponent<IProps, IState> {
     chartDataSets.push(ChartDataSetModel.create({
       name: "Sample Dataset1",
       dataPoints: this.addTestDataPoints(),
-      color: ChartColors[0].hex,
+      // color: ChartColors[3].hex,
+      // pointColors: ["#00ff00", "#ff0000", "#0000ff"],
       maxPoints: 100
     }));
     chartDataSets.push(ChartDataSetModel.create({
       name: "Sample Dataset2",
       dataPoints: this.addTestDataPoints(),
-      color: ChartColors[1].hex,
+      color: "#00ffcc",
+      pointColors: ["#00ff00", "#ff0000", "#0000ff"],
       maxPoints: 100
     }));
     const chartData: ChartDataModelType = ChartDataModel.create({

--- a/src/components/charts/line-graph.tsx
+++ b/src/components/charts/line-graph.tsx
@@ -3,6 +3,7 @@ import { Scatter, ChartData } from "react-chartjs-2";
 import { observer } from "mobx-react";
 import { ChartDataModelType } from "../../models/spaces/charts/chart-data";
 import { ChartOptions } from "chart.js";
+import { ChartColors } from "../../models/spaces/charts/chart-data-set";
 import { hexToRGBValue } from "../../utilities/color-utils";
 
 interface ILineProps {
@@ -55,7 +56,12 @@ const lineDatasetDefaults: ChartData<any> = {
   pointHoverBorderWidth: 2,
   pointRadius: 1,
   pointHitRadius: 10,
-  data: [0]
+  data: [0],
+  backgroundColor: ChartColors.map(c => hexToRGBValue(c.hex, 0.4)),
+  borderColor: ChartColors.map(c => hexToRGBValue(c.hex, 1.0)),
+  pointBorderColor: ChartColors.map(c => hexToRGBValue(c.hex, 1.0)),
+  pointHoverBackgroundColor: ChartColors.map(c => hexToRGBValue(c.hex, 1.0)),
+  pointHoverBorderColor: ChartColors.map(c => hexToRGBValue(c.hex, 1.0))
 };
 
 const lineData = (chartData: ChartDataModelType) => {
@@ -63,13 +69,15 @@ const lineData = (chartData: ChartDataModelType) => {
   for (const d of chartData.dataSets) {
     const dset = Object.assign({}, lineDatasetDefaults, {
       label: d.name,
-      data: d.timeSeriesXY,
-      backgroundColor: hexToRGBValue(d.color, 0.4),
-      borderColor: hexToRGBValue(d.color, 1),
-      pointBorderColor: hexToRGBValue(d.color, 1),
-      pointHoverBackgroundColor: hexToRGBValue(d.color, 1),
-      pointHoverBorderColor: hexToRGBValue(d.color, 1)
+      data: d.timeSeriesXY
     });
+    if (d.color){
+      dset.backgroundColor = hexToRGBValue(d.color, 0.4);
+      dset.borderColor = hexToRGBValue(d.color, 1);
+      dset.pointBorderColor = hexToRGBValue(d.color, 1);
+      dset.pointHoverBackgroundColor = hexToRGBValue(d.color, 1);
+      dset.pointHoverBorderColor = hexToRGBValue(d.color, 1);
+    }
     lineDatasets.push(dset);
   }
 

--- a/src/components/charts/line-graph.tsx
+++ b/src/components/charts/line-graph.tsx
@@ -3,6 +3,7 @@ import { Scatter, ChartData } from "react-chartjs-2";
 import { observer } from "mobx-react";
 import { ChartDataModelType } from "../../models/spaces/charts/chart-data";
 import { ChartOptions } from "chart.js";
+import { hexToRGBValue } from "../../utilities/color-utils";
 
 interface ILineProps {
   chartData: ChartDataModelType;
@@ -63,11 +64,11 @@ const lineData = (chartData: ChartDataModelType) => {
     const dset = Object.assign({}, lineDatasetDefaults, {
       label: d.name,
       data: d.timeSeriesXY,
-      backgroundColor: `rgba(${d.colorRGB},0.4)`,
-      borderColor: `rgba(${d.colorRGB},1)`,
-      pointBorderColor: `rgba(${d.colorRGB},1)`,
-      pointHoverBackgroundColor: `rgba(${d.colorRGB},1)`,
-      pointHoverBorderColor: `rgba(${d.colorRGB},1)`,
+      backgroundColor: hexToRGBValue(d.color, 0.4),
+      borderColor: hexToRGBValue(d.color, 1),
+      pointBorderColor: hexToRGBValue(d.color, 1),
+      pointHoverBackgroundColor: hexToRGBValue(d.color, 1),
+      pointHoverBorderColor: hexToRGBValue(d.color, 1)
     });
     lineDatasets.push(dset);
   }

--- a/src/components/charts/line-graph.tsx
+++ b/src/components/charts/line-graph.tsx
@@ -50,7 +50,6 @@ const lineDatasetDefaults: ChartData<any> = {
   label: "",
   fill: false,
   lineTension: 0.1,
-  pointBackgroundColor: "#fff",
   pointBorderWidth: 1,
   pointHoverRadius: 5,
   pointHoverBorderWidth: 2,
@@ -58,6 +57,7 @@ const lineDatasetDefaults: ChartData<any> = {
   pointHitRadius: 10,
   data: [0],
   backgroundColor: ChartColors.map(c => hexToRGBValue(c.hex, 0.4)),
+  pointBackgroundColor: ChartColors.map(c => hexToRGBValue(c.hex, 0.4)),
   borderColor: ChartColors.map(c => hexToRGBValue(c.hex, 1.0)),
   pointBorderColor: ChartColors.map(c => hexToRGBValue(c.hex, 1.0)),
   pointHoverBackgroundColor: ChartColors.map(c => hexToRGBValue(c.hex, 1.0)),
@@ -71,12 +71,23 @@ const lineData = (chartData: ChartDataModelType) => {
       label: d.name,
       data: d.timeSeriesXY
     });
-    if (d.color){
+    if (d.color) {
+      // backgroundColor is the color under the line, if we decide to fill that area
       dset.backgroundColor = hexToRGBValue(d.color, 0.4);
+      // borderColor is the color of the line
       dset.borderColor = hexToRGBValue(d.color, 1);
       dset.pointBorderColor = hexToRGBValue(d.color, 1);
       dset.pointHoverBackgroundColor = hexToRGBValue(d.color, 1);
       dset.pointHoverBorderColor = hexToRGBValue(d.color, 1);
+    }
+    if (d.pointColors) {
+      // If we have specified point colors, use those first,
+      // then if we run out of colors we fall back to the defaults
+      const colors = d.pointColors.concat(ChartColors.map(c => c.hex));
+      dset.pointBackgroundColor = colors.map(c => hexToRGBValue(c, 0.4));
+      dset.pointBorderColor = colors.map(c => hexToRGBValue(c, 1.0));
+      dset.pointHoverBackgroundColor = colors.map(c => hexToRGBValue(c, 1.0));
+      dset.pointHoverBorderColor = colors.map(c => hexToRGBValue(c, 1.0));
     }
     lineDatasets.push(dset);
   }

--- a/src/models/spaces/cell-zoom/cell-zoom.ts
+++ b/src/models/spaces/cell-zoom/cell-zoom.ts
@@ -120,7 +120,10 @@ export const CellZoomModel = types
       chartDataSets.push(ChartDataSetModel.create({
         name: "Sample Dataset1",
         dataPoints: points,
-        color: ChartColors[0].hex,
+        color: ChartColors[0].hex, // all bars will be this color
+        // alternatively, use a specified array of specific colors for each bar:
+        // pointColors: ["#00ff00", "#ff0000"]
+        // if no color and no pointColors are specified, each bar will take on a color from ChartColors
         maxPoints: 100
       }));
 

--- a/src/models/spaces/charts/chart-data-set.ts
+++ b/src/models/spaces/charts/chart-data-set.ts
@@ -1,6 +1,7 @@
 import { types, Instance } from "mobx-state-tree";
 // @ts-ignore
 import * as colors from "../../../components/colors.scss";
+import { hexToRGB } from "../../../utilities/color-utils";
 
 export interface Color {
   name: string;
@@ -17,7 +18,7 @@ export const ChartColors: Color[] = [
   { name: "blue", hex: colors.chartDataColor1},
   { name: "orange", hex: colors.chartDataColor2},
   { name: "purple", hex: colors.chartDataColor3},
-  { name: "green", hex: colors.chartDataColor4 },
+  { name: "green", hex: colors.chartDataColor4},
   { name: "sage", hex: colors.chartDataColor5},
   { name: "rust", hex: colors.chartDataColor6},
   { name: "cloud", hex: colors.chartDataColor7},
@@ -33,15 +34,6 @@ export const ChartColors: Color[] = [
   { name: "terra", hex: colors.chartColor9},
   { name: "sky", hex: colors.chartColor10}
 ];
-
-function hexToRgb(hex: string) {
-  const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
-  return result ? {
-    r: parseInt(result[1], 16),
-    g: parseInt(result[2], 16),
-    b: parseInt(result[3], 16)
-  } : null;
-}
 
 function timeSeriesSort(a: XYPoint, b: XYPoint) {
   if (a.x < b.x) {
@@ -157,14 +149,6 @@ export const ChartDataSetModel = types
       const xyData = self.visibleDataPoints.map(d => ({ x: d.a1, y: d.a2 }));
       xyData.sort(timeSeriesSort);
       return xyData;
-    },
-    get colorRGB(): string {
-      const colorValues = hexToRgb(self.color);
-      if (colorValues) {
-        return colorValues.r + "," + colorValues.g + "," + colorValues.b;
-      } else {
-        return "170, 170, 170";
-      }
     }
   }))
   .extend(self => {

--- a/src/models/spaces/charts/chart-data-set.ts
+++ b/src/models/spaces/charts/chart-data-set.ts
@@ -60,7 +60,11 @@ export const ChartDataSetModel = types
   .model("ChartDataSet", {
     name: types.string,
     dataPoints: types.array(DataPoint),
+    // A single color will apply to a whole dataset (a line on a line graph, or all bars on a bar chart)
     color: types.maybe(types.string),
+    // An array will vary each point's color
+    // useful for bar charts with different color bars or scatter plots with each point a different color
+    pointColors: types.maybe(types.array(types.string)),
     // If maxPoints is 0 we will always work with the entire data set
     maxPoints: types.optional(types.number, -1),
     fixedMin: types.maybe(types.number),

--- a/src/models/spaces/charts/chart-data-set.ts
+++ b/src/models/spaces/charts/chart-data-set.ts
@@ -65,6 +65,8 @@ export const ChartDataSetModel = types
     // An array will vary each point's color
     // useful for bar charts with different color bars or scatter plots with each point a different color
     pointColors: types.maybe(types.array(types.string)),
+    // For bars, can vary opacity of the bar by dataset to show a second dataset with less opacity
+    backgroundOpacity: types.maybe(types.number),
     // If maxPoints is 0 we will always work with the entire data set
     maxPoints: types.optional(types.number, -1),
     fixedMin: types.maybe(types.number),

--- a/src/models/spaces/charts/chart-data-set.ts
+++ b/src/models/spaces/charts/chart-data-set.ts
@@ -60,7 +60,7 @@ export const ChartDataSetModel = types
   .model("ChartDataSet", {
     name: types.string,
     dataPoints: types.array(DataPoint),
-    color: types.string,
+    color: types.maybe(types.string),
     // If maxPoints is 0 we will always work with the entire data set
     maxPoints: types.optional(types.number, -1),
     fixedMin: types.maybe(types.number),

--- a/src/utilities/color-utils.ts
+++ b/src/utilities/color-utils.ts
@@ -1,0 +1,24 @@
+
+export function hexToRGBValue(hex: string, alpha: number) {
+  const convertedHexValue = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+  const rgb =  convertedHexValue ? {
+    r: parseInt(convertedHexValue[1], 16),
+    g: parseInt(convertedHexValue[2], 16),
+    b: parseInt(convertedHexValue[3], 16)
+  } : null;
+
+  if (rgb) {
+    return `rgba(${rgb.r},${rgb.g},${rgb.b},${alpha})`;
+  } else {
+    return "rgba(170, 170, 170,1.0)";
+  }
+}
+
+export function hexToRGB(hex: string) {
+  const convertedHexValue = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+  return convertedHexValue ? {
+    r: parseInt(convertedHexValue[1], 16),
+    g: parseInt(convertedHexValue[2], 16),
+    b: parseInt(convertedHexValue[3], 16)
+  } : null;
+}


### PR DESCRIPTION
Bar charts changed to  display each data series as a different color, plus moved color helper functions to separate utility file and adjusted line rendering to use new helpers. I'm not sure at this time whether we should retain the ability to show datasets as one color on a bar chart - I haven't seen a design requirement for this as yet so I've left it out for now.