### PR TITLE
162054341 organism authored instructions

### DIFF
--- a/src/components/instructions.sass
+++ b/src/components/instructions.sass
@@ -3,4 +3,5 @@
 .authored-markdown
   font-family: $font-stack
   padding: $component-padding
+  text-align: left
 

--- a/src/components/instructions.tsx
+++ b/src/components/instructions.tsx
@@ -16,9 +16,11 @@ export class InstructionsComponent extends BaseComponent<IProps, IState> {
 
   public render() {
     return (
-      <Markdown className="authored-markdown">
-        {this.props.content}
-      </Markdown>
+      <div className="authored-markdown">
+        <Markdown>
+          {this.props.content}
+        </Markdown>
+      </div>
     );
   }
 }

--- a/src/components/spaces/organisms-space.tsx
+++ b/src/components/spaces/organisms-space.tsx
@@ -4,6 +4,7 @@ import { BaseComponent, IBaseProps } from "../base";
 import { TwoUpDisplayComponent } from "../two-up-display";
 import { FourUpDisplayComponent } from "../four-up-display";
 import { Chart } from "../charts/chart";
+import { InstructionsComponent } from "../instructions";
 
 import { OrganismsContainer } from "./organisms/organisms-container";
 
@@ -28,22 +29,32 @@ export class OrganismsSpaceComponent extends BaseComponent<IProps, IState> {
   }
 
   private getOrganismsRow(rowIndex: number) {
-    const { organisms } = this.stores;
+    const { ui, organisms } = this.stores;
     const row = organisms.rows[rowIndex];
     const { currentData } = row;
-
-    const graphTitle = "Graph";
+    const showOrganismGraph = ui.showOrganismGraph[rowIndex];
+    const iconId = showOrganismGraph ? "#icon-show-data" : "#icon-show-graph";
+    const graphTitle = showOrganismGraph ? "Graph" : "Instructions";
     const graphPanel = <Chart title="Chart Test" chartData={currentData}
       chartType={"horizontalBar"} />;
+    const instructionsPanel = <InstructionsComponent content={organisms.instructions}/>;
+    const rightPanelContent = showOrganismGraph ? graphPanel : instructionsPanel;
 
     return (
       <TwoUpDisplayComponent
         leftTitle="Investigate: Cell"
         leftPanel={<OrganismsContainer rowIndex={rowIndex}/>}
         rightTitle={graphTitle}
-        rightPanel={graphPanel}
+        rightIcon={iconId}
+        rightPanel={rightPanelContent}
+        onClickRightIcon={this.toggleOrganismsGraph(rowIndex)}
       />
     );
+  }
+
+  private toggleOrganismsGraph = (rowIndex: number) => (e: any) => {
+    const {ui} = this.stores;
+    ui.setShowOrganismGraph(rowIndex, !ui.showOrganismGraph[rowIndex]);
   }
 
 }

--- a/src/components/spaces/populations-space.tsx
+++ b/src/components/spaces/populations-space.tsx
@@ -17,9 +17,7 @@ export class PopulationsSpaceComponent extends BaseComponent<IProps, IState> {
     const {ui, populations} = this.stores;
     const showPopulationGraph = ui.showPopulationGraph;
     const iconId = showPopulationGraph ? "#icon-show-data" : "#icon-show-graph";
-    const graphTitle = showPopulationGraph ? "Graph" : "Data";
-    const contentText = showPopulationGraph ? "Graph goes here" :
-                                                     "Data goes here";
+    const graphTitle = showPopulationGraph ? "Graph" : "Instructions";
     const graphPanel = <Chart title="Chart Test" chartData={populations.currentData} chartType={"line"} />;
     const instructionsPanel = <InstructionsComponent content={populations.instructions}/>;
     const rightPanelContent = ui.showPopulationGraph ? graphPanel : instructionsPanel;

--- a/src/components/two-up-display.tsx
+++ b/src/components/two-up-display.tsx
@@ -9,7 +9,7 @@ interface IProps extends IBaseProps {
   leftPanel: React.ReactNode;
   rightTitle: string;
   rightIcon?: string;
-  onClickRightIcon?: () => void;
+  onClickRightIcon?: (row?: number) => void;
   rightPanel: React.ReactNode;
 }
 interface IState {}

--- a/src/models/spaces/organisms/organisms-space.ts
+++ b/src/models/spaces/organisms/organisms-space.ts
@@ -85,7 +85,8 @@ export const OrganismsSpaceModel = types
   .model("OrganismsSpace", {
     organismsMice: types.array(OrganismsMouseModel),
     rows: types.optional(types.array(OrganismsRowModel),
-      [OrganismsRowModel.create(), OrganismsRowModel.create()])
+      [OrganismsRowModel.create(), OrganismsRowModel.create()]),
+    instructions: ""
   })
   .actions((self) => {
     function clearRowBackpackMouse(rowIndex: number) {

--- a/src/models/stores.ts
+++ b/src/models/stores.ts
@@ -32,6 +32,7 @@ export function createStores(params: ICreateStores, authoring: any): IStores {
       createPopulationsModel(authoring.curriculum, flatten(authoring.populations)),
     backpack: params && params.backpack
       || BackpackModel.create({}),
-    organisms: params && params.organisms || OrganismsSpaceModel.create()
+    organisms: params && params.organisms ||
+      OrganismsSpaceModel.create({instructions: authoring.organism.instructions})
   };
 }

--- a/src/models/ui.ts
+++ b/src/models/ui.ts
@@ -12,6 +12,7 @@ export function createUIModel(authoring: any): UIModelType {
         displayedSpace = "none";
   }
   return UIModel.create({
+    showOrganismGraph: [false, true],
     investigationPanelSpace: displayedSpace,
     showPopulationSpace: authoring.showPopulationSpace,
     showBreedingSpace: authoring.showBreedingSpace,
@@ -23,6 +24,7 @@ export function createUIModel(authoring: any): UIModelType {
 export const UIModel = types
   .model("UI", {
     showPopulationGraph: false,
+    showOrganismGraph: types.array(types.boolean),
     investigationPanelSpace: SpaceTypeEnum,
     availableBackpackSlots: 6,
     showPopulationSpace: true,
@@ -32,6 +34,9 @@ export const UIModel = types
   })
   .actions((self) => {
     return {
+      setShowOrganismGraph(rowIndex: number, val: boolean) {
+        self.showOrganismGraph[rowIndex] = val;
+      },
       setShowPopulationGraph(val: boolean) {
         self.showPopulationGraph = val;
       },


### PR DESCRIPTION
Add the organism level markdown instructions via the authoring tool.  Instructions are placed in both right panels of the 4-up display in the organism view.  By default, the top set of instructions is shown (the bottom panel displays the graph/data by default).