### PR TITLE
Cleaning up the assay/organism view

### DIFF
--- a/src/components/spaces/organisms/manipulation-controls.tsx
+++ b/src/components/spaces/organisms/manipulation-controls.tsx
@@ -26,7 +26,7 @@ export class ManipulationControls extends BaseComponent<IProps, IState> {
     const inspectClass = "assay" + inspectDisabledClass + inspectActiveClass;
     return (
       <div className="manipulation-controls" data-test="manipulations-panel">
-        <div className={assayClass} onClick={this.handleAssayClick}>Assay</div>
+        <div className={assayClass} onClick={this.handleAssayClick}>Measure</div>
         <div className={inspectClass} onClick={this.handleInspectClick}>Inspect</div>
       </div>
     );

--- a/src/components/spaces/organisms/organelle-wrapper.sass
+++ b/src/components/spaces/organisms/organelle-wrapper.sass
@@ -10,11 +10,11 @@
 
 .hover-location
     position: absolute
-    bottom: 5px
+    top: 45px
     right: 5px
     min-width: 94px
     height: 18px
-    background: #FFFFFF88
+    background: #FFFFFFAA
     border: 1px solid #444
     padding: 2px
     text-align: center

--- a/src/components/spaces/organisms/organism-view.tsx
+++ b/src/components/spaces/organisms/organism-view.tsx
@@ -35,7 +35,6 @@ export class OrganismView extends BaseComponent<IProps, IState> {
 
     return (
       <div className="organism-view-container">
-        <div className="organism-description" data-test="organism-description">{mouseDescription}</div>
         {backpackMouse &&
           <div className="organism-view" style={mouseStyle} data-test="organism-view" />
         }


### PR DESCRIPTION
Small style changes if you don't mind taking a quick look @mklewandowski!

- "Assay" button now reads "Measure"
- Hovered organelle is moved to the top right corner for smaller screens
- Organism label is hidden