### PR TITLE
162487966 multiple assays

### DIFF
--- a/src/components/charts/bar-chart.tsx
+++ b/src/components/charts/bar-chart.tsx
@@ -15,7 +15,7 @@ interface IBarProps {
 
 const defaultOptions: ChartOptions = {
   title: {
-    display: true,
+    display: false,
     text: "",
     fontSize: 22
   },
@@ -82,11 +82,12 @@ const barData = (chartData: ChartDataModelType) => {
       dset.backgroundColor = ChartColors.map(c => hexToRGBValue(c.hex, seriesOpacity));
       dset.borderColor = ChartColors.map(c => hexToRGBValue(c.hex, 1.0));
     }
+    dset.stack = d.stack;
     barDatasets.push(dset);
   }
 
   const barChartData = {
-    labels: chartData.dataLabels,
+    labels: chartData.chartLabels,
     datasets: barDatasets
   };
 

--- a/src/components/charts/chart.sass
+++ b/src/components/charts/chart.sass
@@ -1,11 +1,12 @@
 @import ../vars
 
 .chart-container
-  max-height: 400px
+  max-height: 360px
   background-color: white
+  margin: $component-margin
 
   .chart-display
-    max-height: 400px
+    max-height: 360px
 
     .line-chart-container
       position: relative

--- a/src/components/charts/chart.sass
+++ b/src/components/charts/chart.sass
@@ -1,14 +1,12 @@
 @import ../vars
 
 .chart-container
-  max-height: 360px
+  width: 100%
   background-color: white
-  margin: $component-margin
+  display: flex
 
-  .chart-display
-    max-height: 360px
-
-    .line-chart-container
-      position: relative
-      height: 100%
-      width: 100%
+  .line-chart-container
+    display: flex
+    flex-direction: column
+    height: 100%
+    width: 100%

--- a/src/components/charts/chart.tsx
+++ b/src/components/charts/chart.tsx
@@ -41,9 +41,7 @@ export class Chart extends React.Component<IChartProps, IChartState> {
       />;
     return (
       <div className="chart-container">
-        <div className="chart-display" data-test="chart-display">
-          {chart}
-        </div>
+        {chart}
       </div>
     );
   }

--- a/src/components/charts/line-chart-controls.sass
+++ b/src/components/charts/line-chart-controls.sass
@@ -7,6 +7,7 @@
   margin-left: 8%
   margin-right: 4%
   margin-top: 5px
+  flex: 0 0 20px
 
   .scrubber
     position: absolute

--- a/src/components/charts/line-chart.tsx
+++ b/src/components/charts/line-chart.tsx
@@ -30,7 +30,7 @@ const defaultOptions: ChartOptions = {
     display: true,
     position: "bottom",
   },
-  maintainAspectRatio: true,
+  maintainAspectRatio: false,
   scales: {
     display: false,
     yAxes: [{
@@ -161,8 +161,10 @@ export class LineChart extends BaseComponent<ILineProps, ILineState> {
     );
 
     return (
-      <div className="line-chart-container" data-test="line-chart">
-        {graphs}
+      <div className="line-chart-container">
+        <div className="line-chart-container" data-test="line-chart">
+          {graphs}
+        </div>
         <LineChartControls chartData={chartData} isPlaying={isPlaying} />
       </div>
     );

--- a/src/components/two-up-display.sass
+++ b/src/components/two-up-display.sass
@@ -53,6 +53,9 @@
         height: $two-up-button-icon-height
         width: $two-up-button-icon-width
         fill: $color-khaki-yellow
+      &.active
+        .button
+          fill: $two-up-button-icon-color-active
 
     &.organism
       .button-holder
@@ -75,6 +78,15 @@
     flex-grow: 1
     overflow: hidden
     position: relative
+
+    &.populations
+      background-color: $color-khaki-yellow-light2
+
+    &.organism
+      background-color: $color-salmon-orange-light2
+
+  .resizetofit
+    display: flex
 
   .scrollable
     overflow: auto

--- a/src/components/two-up-display.tsx
+++ b/src/components/two-up-display.tsx
@@ -43,7 +43,7 @@ export class TwoUpDisplayComponent extends BaseComponent<IProps, IState> {
         <div className={"header " + this.props.spaceClass} data-test="left-header">
           <div className="title" data-test="left-title">{this.props.leftTitle}</div>
         </div>
-        <div className="content" data-test="left-content">
+        <div className={"content " + this.props.spaceClass} data-test="left-content">
           {this.props.leftPanel}
         </div>
       </div>
@@ -67,7 +67,9 @@ export class TwoUpDisplayComponent extends BaseComponent<IProps, IState> {
   private renderRightPanel() {
     const { selectedRightPanel, instructionsIconEnabled, dataIconEnabled, informationIconEnabled } = this.props;
     const title = titles[selectedRightPanel];
-    const contentClass = "content" + (selectedRightPanel === "instructions" ? " scrollable" : "");
+    const contentClass = "content " + (selectedRightPanel === "instructions" ? " scrollable " : "")
+                                    + (selectedRightPanel === "data" ? "resizetofit " : "")
+                                    + this.props.spaceClass;
     return (
       <div className="two-up-panel right-abutment">
         <div className={"header " + this.props.spaceClass} data-test="right-header">

--- a/src/models/spaces/charts/chart-data-set.ts
+++ b/src/models/spaces/charts/chart-data-set.ts
@@ -77,7 +77,8 @@ export const ChartDataSetModel = types
     // if this is set the a2 / y axis max returns the max of the full data set, not just the visiblePoints
     expandOnly: false,
     fixedLabelRotation: types.maybe(types.number),
-    dataStartIdx: types.maybe(types.number)
+    dataStartIdx: types.maybe(types.number),
+    stack: types.maybe(types.string)
   })
   .views(self => ({
     get visibleDataPoints() {

--- a/src/models/spaces/charts/chart-data.ts
+++ b/src/models/spaces/charts/chart-data.ts
@@ -4,9 +4,15 @@ import { ChartDataSetModel, ChartDataSetModelType, ChartColors } from "./chart-d
 export const ChartDataModel = types
   .model("ChartData", {
     name: types.string,
-    dataSets: types.array(ChartDataSetModel)
+    dataSets: types.array(ChartDataSetModel),
+    labels: types.array(types.string)
   })
   .views(self => ({
+    get chartLabels() {
+      if (self.labels && self.labels.length > 0) {
+        return self.labels;
+      } else return [];
+    },
     // labels for a data point - essential for a bar graph, optional for a line
     get dataLabels() {
       if (self.dataSets && self.dataSets.length > 0) {

--- a/src/models/spaces/organisms/organisms-row.ts
+++ b/src/models/spaces/organisms/organisms-row.ts
@@ -1,8 +1,8 @@
 import { types, Instance } from "mobx-state-tree";
 import { ChartDataModelType, ChartDataModel } from "../charts/chart-data";
-import { DataPoint, ChartDataSetModel, ChartColors, DataPointType } from "../charts/chart-data-set";
+import { DataPoint, ChartDataSetModel, ChartDataSetModelType, DataPointType } from "../charts/chart-data-set";
 import { OrganismsMouseModel } from "./organisms-mouse";
-import { kSubstanceNames } from "./organisms-space";
+import { kSubstanceInfo, kSubstanceNames } from "./organisms-space";
 
 export const Organelle = types.enumeration("type", [
   "nucleus",
@@ -38,20 +38,15 @@ export const OrganismsRowModel = types
   })
   .views(self => ({
     get currentData(): ChartDataModelType {
-      const chartDataSets: any[] = [];
+      const chartDataSets: ChartDataSetModelType[] = [];
       const organelleLabels: string[] = [];
 
       self.assayedOrganelles.forEach((organelle) => {
         organelleLabels.push(organelle);
       });
-      const colorMaps: any = { pheomelanin: "#f4ce83",
-                               signalProtein: "#d88bff",
-                               eumelanin: "#795423",
-                               hormone: "#0adbd7" };
-      let stackIterator = 0;
-      kSubstanceNames.forEach((substance) => {
-        const substanceName = substance === "signalProtein" ? "signal protein" : substance;
-        const substanceColor: string = colorMaps[substance];
+      kSubstanceNames.forEach((substance, index) => {
+        const substanceName: string = kSubstanceInfo[substance].displayName;
+        const substanceColor: string =  kSubstanceInfo[substance].color;
         const points: DataPointType[] = [];
         self.assayedOrganelles.forEach((organelle) => {
           if (!self.organismsMouse) {
@@ -60,7 +55,7 @@ export const OrganismsRowModel = types
           const substanceValue = self.organismsMouse.getSubstanceValue(organelle, substance);
           points.push(DataPoint.create({ a1: substanceValue, a2: 0, label: `${organelle} ${substanceName}` }));
         });
-        const stackNum = "Stack " + stackIterator;
+        const stackNum = "Stack " + index;
         chartDataSets.push(ChartDataSetModel.create({
           name: substanceName,
           dataPoints: points,
@@ -69,7 +64,6 @@ export const OrganismsRowModel = types
           fixedMaxA1: 800,
           stack: stackNum
         }));
-        stackIterator++;
       });
 
       const chart = ChartDataModel.create({

--- a/src/models/spaces/organisms/organisms-row.ts
+++ b/src/models/spaces/organisms/organisms-row.ts
@@ -30,7 +30,7 @@ export const OrganismsRowModel = types
     hoveredOrganelle: types.maybe(Organelle),
     selectedOrganelle: types.maybe(Organelle),
     mode: types.optional(Mode, "normal"),
-    assayedOrganelle: types.maybe(Organelle),
+    assayedOrganelles: types.array(Organelle),
     zoomLevel: types.optional(ZoomLevel, "organism"),
     showProteinDNA: false,
     showProteinAminoAcidsOnProtein: false,
@@ -38,28 +38,44 @@ export const OrganismsRowModel = types
   })
   .views(self => ({
     get currentData(): ChartDataModelType {
-      const chartDataSets = [];
-      const points: DataPointType[] = [];
-      const organelle = self.assayedOrganelle;
-      if (organelle) {
-        kSubstanceNames.forEach((substance) => {
+      const chartDataSets: any[] = [];
+      const organelleLabels: string[] = [];
+
+      self.assayedOrganelles.forEach((organelle) => {
+        organelleLabels.push(organelle);
+      });
+      const colorMaps: any = { pheomelanin: "#f4ce83",
+                               signalProtein: "#d88bff",
+                               eumelanin: "#795423",
+                               hormone: "#0adbd7" };
+      let stackIterator = 0;
+      kSubstanceNames.forEach((substance) => {
+        const substanceName = substance === "signalProtein" ? "signal protein" : substance;
+        const substanceColor: string = colorMaps[substance];
+        const points: DataPointType[] = [];
+        self.assayedOrganelles.forEach((organelle) => {
           if (!self.organismsMouse) {
             return;
           }
           const substanceValue = self.organismsMouse.getSubstanceValue(organelle, substance);
-          points.push(DataPoint.create({ a1: substanceValue, a2: 0, label: `${organelle} ${substance}` }));
+          points.push(DataPoint.create({ a1: substanceValue, a2: 0, label: `${organelle} ${substanceName}` }));
         });
-      }
-
-      chartDataSets.push(ChartDataSetModel.create({
-        name: self.assayedOrganelle || "",
-        dataPoints: points,
-        pointColors: ["#f4ce83", "#d88bff", "#795423", "#0adbd7"]
-      }));
+        const stackNum = "Stack " + stackIterator;
+        chartDataSets.push(ChartDataSetModel.create({
+          name: substanceName,
+          dataPoints: points,
+          color: substanceColor,
+          fixedMaxA2: 800,
+          fixedMaxA1: 800,
+          stack: stackNum
+        }));
+        stackIterator++;
+      });
 
       const chart = ChartDataModel.create({
-        name: "Samples",
-        dataSets: chartDataSets
+        name: "Substance Data",
+        dataSets: chartDataSets,
+        labels: organelleLabels,
       });
       return chart;
     }
@@ -70,7 +86,9 @@ export const OrganismsRowModel = types
         self.hoveredOrganelle = organelle;
       },
       setActiveAssay(organelle: OrganelleType) {
-        self.assayedOrganelle = organelle;
+        if (self.assayedOrganelles.indexOf(organelle) === -1) {
+          self.assayedOrganelles.push(organelle);
+        }
       },
       setSelectedOrganelle(organelle: OrganelleType) {
         self.selectedOrganelle = organelle;

--- a/src/models/spaces/organisms/organisms-space.ts
+++ b/src/models/spaces/organisms/organisms-space.ts
@@ -15,6 +15,31 @@ export const kSubstanceNames = [
 export const Substance = types.enumeration("Substance", kSubstanceNames);
 export type SubstanceType = typeof Substance.Type;
 
+type SubstanceInfo = {
+  [substance in SubstanceType]: {
+    displayName: string;
+    color: string;
+  };
+};
+export const kSubstanceInfo: SubstanceInfo = {
+  pheomelanin: {
+    displayName: "pheomelanin",
+    color: "#f4ce83"
+  },
+  signalProtein: {
+    displayName: "signal protein",
+    color: "#d88bff"
+  },
+  eumelanin: {
+    displayName: "eumelanin",
+    color: "#795423"
+  },
+  hormone: {
+    displayName: "hormone",
+    color: "#0adbd7"
+  },
+};
+
 type OrganelleInfo = {
   [organelle in OrganelleType]: {
     displayName: string;


### PR DESCRIPTION
This branch includes changes to allow for multiple organism level assays to be displayed in a graph in the right panel which follows the layout/format of the previous version of connected bio.  Graphs are scaled to fit into a given view (which includes changes to allow the population graph to do so as well).  A few notes:
 - there is probably some cleanup needed here, but I would rather have people start looking at it sooner rather than later
- Editing my previous comment.  I squashed the commit history down to just two items: the changes to add multiple assays to the graph and the changes to improve graph sizing and scaling.  This cleans up some of the wildness from yesterday.  These commits are not as nuanced as I would like, but it's better than the 10 or so previous commits that had changes being added and then removed.
- this has been rebased into master, and I made some changes to get it working with the last batch of changes there.  Nonetheless, changes are coming in rapidly, so we should double-check to make certain content works as expected in all views