### PR TITLE
Show graph when user select assay tool

### DIFF
--- a/src/components/spaces/organisms/manipulation-controls.tsx
+++ b/src/components/spaces/organisms/manipulation-controls.tsx
@@ -43,6 +43,8 @@ export class ManipulationControls extends BaseComponent<IProps, IState> {
 
     if (row.mode === "normal") {
       row.setMode("assay");
+      const { ui } = this.stores;
+      ui.setOrganismRightPanel(this.props.rowIndex, "data"); // auto-switch to graph
     } else {
       row.setMode("normal");
     }


### PR DESCRIPTION
This change shows the graph when the user selects the assay tool.  This should have been handled in my previous batch of graph updates, but the change was missed.  I was reminded of it when reviewing my notes and wanted to get something in since Frieda specifically requested it during the demo meeting. 