### PR TITLE
Rename B-b alleles to R-C everywhere

### DIFF
--- a/src/components/collect-button.tsx
+++ b/src/components/collect-button.tsx
@@ -88,8 +88,8 @@ export class CollectButtonComponent extends BaseComponent<IProps, IState> {
     }
 
     const randSex = Math.random() > .5 ? "male" : "female";
-    const randGenotype = Math.random() > .5 ? (Math.random() > .5 ? "BB" : "Bb") :
-                                                  (Math.random() > .5 ? "bB" : "bb");
+    const randGenotype = Math.random() > .5 ? (Math.random() > .5 ? "RR" : "RC") :
+                                                  (Math.random() > .5 ? "CR" : "CC");
     backpack.addCollectedMouse(BackpackMouse.create({sex: randSex, genotype: randGenotype, label: randGenotype}));
   }
   private handleClickRemove = () => {

--- a/src/models/backpack-mouse.test.ts
+++ b/src/models/backpack-mouse.test.ts
@@ -6,25 +6,25 @@ describe("mouse model", () => {
   beforeEach(() => {
     mouse = BackpackMouse.create({
       sex: "male",
-      genotype: "BB",
+      genotype: "RR",
       label: "lbl"
     });
   });
 
   it("has default values", () => {
     expect(mouse.sex).toBe("male");
-    expect(mouse.genotype).toBe("BB");
+    expect(mouse.genotype).toBe("RR");
     expect(mouse.label).toBe("lbl");
   });
 
   it("uses override values", () => {
     mouse = BackpackMouse.create({
       sex: "female",
-      genotype: "bb",
+      genotype: "CC",
       label: "lbl"
     });
     expect(mouse.sex).toBe("female");
-    expect(mouse.genotype).toBe("bb");
+    expect(mouse.genotype).toBe("CC");
     expect(mouse.label).toBe("lbl");
   });
 

--- a/src/models/backpack-mouse.ts
+++ b/src/models/backpack-mouse.ts
@@ -7,7 +7,7 @@ export type ColorType = typeof MouseColor.Type;
 export const SexTypeEnum = types.enumeration("type", ["male", "female"]);
 export type SexType = typeof SexTypeEnum.Type;
 
-export const GenotypeEnum = types.enumeration("type", ["BB", "Bb", "bB", "bb"]);
+export const GenotypeEnum = types.enumeration("type", ["RR", "RC", "CR", "CC"]);
 export type Genotype = typeof GenotypeEnum.Type;
 
 export const UNCOLLECTED_IMAGE = "assets/mouse_collect.png";
@@ -22,9 +22,9 @@ export const BackpackMouse = types
   .views(self => ({
     get baseColor(): ColorType {
       switch (self.genotype) {
-        case "BB":
+        case "RR":
           return "brown";
-        case "bb":
+        case "CC":
           return "white";
         default:
           return "tan";
@@ -32,16 +32,16 @@ export const BackpackMouse = types
     },
     get baseImage(): string {
       switch (self.genotype) {
-        case "BB":
+        case "RR":
           return "assets/mouse_field.png";
-        case "bb":
+        case "CC":
           return "assets/mouse_beach.png";
         default:
           return "assets/mouse_tan.png";
       }
     },
     get isHeterozygote(): boolean {
-      return (self.genotype === "Bb" || self.genotype === "bB");
+      return (self.genotype === "RC" || self.genotype === "CR");
     },
     setLabel(val: string) {
       self.label = val;

--- a/src/models/backpack.test.ts
+++ b/src/models/backpack.test.ts
@@ -13,7 +13,7 @@ describe("backpack model", () => {
   });
 
   it("uses changes values", () => {
-    backpack.addCollectedMouse(BackpackMouse.create({sex: "male", genotype: "BB"}));
+    backpack.addCollectedMouse(BackpackMouse.create({sex: "male", genotype: "RR"}));
     expect(backpack.collectedMice.length).toBe(1);
     backpack.removeCollectedMouse(0);
     expect(backpack.collectedMice.length).toBe(0);
@@ -21,15 +21,15 @@ describe("backpack model", () => {
 
   it("has a maximum number of slots that can be used", () => {
     for (let i = 0; i < 5; i++) {
-      backpack.addCollectedMouse(BackpackMouse.create({sex: "male", genotype: "BB"}));
+      backpack.addCollectedMouse(BackpackMouse.create({sex: "male", genotype: "RR"}));
     }
     expect(backpack.collectedMice.length).toBe(5);
 
-    let addedSucessfully = backpack.addCollectedMouse(BackpackMouse.create({sex: "male", genotype: "BB"}));
+    let addedSucessfully = backpack.addCollectedMouse(BackpackMouse.create({sex: "male", genotype: "RR"}));
     expect(addedSucessfully).toBe(true);
     expect(backpack.collectedMice.length).toBe(6);
 
-    addedSucessfully = backpack.addCollectedMouse(BackpackMouse.create({sex: "male", genotype: "BB"}));
+    addedSucessfully = backpack.addCollectedMouse(BackpackMouse.create({sex: "male", genotype: "RR"}));
     expect(addedSucessfully).toBe(false);
     expect(backpack.collectedMice.length).toBe(6);
   });

--- a/src/models/spaces/populations/mouse-model/hawks-mice-interactive.ts
+++ b/src/models/spaces/populations/mouse-model/hawks-mice-interactive.ts
@@ -144,17 +144,17 @@ export function createInteractive(model: MousePopulationsModelType) {
     let alleleString;
     switch (color) {
       case "white":
-        alleleString = "a:b,b:b";
+        alleleString = "a:C,b:C";
         break;
       case "tan":
         const rand = Math.random();
         alleleString = rand < 0.5
-          ? "a:b,b:B"
-          : "a:B,b:b";
+          ? "a:C,b:R"
+          : "a:R,b:C";
         break;
       case "brown":
       default:
-        alleleString = "a:B,b:B";
+        alleleString = "a:R,b:R";
         break;
     }
     return createColorTraitByGenotype(alleleString);
@@ -249,13 +249,13 @@ export function createInteractive(model: MousePopulationsModelType) {
       // Make sure there are *some* white mice to ensure white mice are possible
       if (numWhite > 0 && numWhite < 10) {
         for (let i = 0; i < 3; i++) {
-          addAgent(mouseSpecies, [], [createColorTraitByGenotype("a:b,b:b")]);
+          addAgent(mouseSpecies, [], [createColorTraitByGenotype("a:C,b:C")]);
         }
       }
 
       if (numBrown > 0 && numBrown < 10) {
         for (let i = 0; i < 3; i++) {
-          addAgent(mouseSpecies, [], [createColorTraitByGenotype("a:B,b:B")]);
+          addAgent(mouseSpecies, [], [createColorTraitByGenotype("a:R,b:R")]);
         }
       }
     }

--- a/src/models/spaces/populations/mouse-model/mice.ts
+++ b/src/models/spaces/populations/mouse-model/mice.ts
@@ -5,7 +5,7 @@ const MouseGeneticSpec = {
   name: "Mouse",
   chromosomeNames: ["1", "XY"],
   chromosomeGeneMap: {
-    1: ["B"],
+    1: ["R"],
     XY: []
   },
   chromosomesLength: {
@@ -15,22 +15,22 @@ const MouseGeneticSpec = {
   },
   geneList: {
     color: {
-      alleles: ["B", "b"],
+      alleles: ["R", "C"],
       weights: [.5, .5],
       start: 10000000,
       length: 10584
     }
   },
   alleleLabelMap: {
-    "B": "Brown",
-    "b": "White",
+    "R": "Brown",
+    "C": "White",
     "": ""
   },
   traitRules: {
     color: {
-      white: [["b", "b"]],
-      tan: [["B", "b"]],
-      brown: [["B", "B"]]
+      white: [["C", "C"]],
+      tan: [["R", "C"]],
+      brown: [["R", "R"]]
     }
   }
 };
@@ -130,11 +130,11 @@ export function getMouseSpecies(model: MousePopulationsModelType) {
       const tanChance = whiteChance + model["inheritance.randomOffspring.tan"] / 100;
       const rand = Math.random();
       if (rand < whiteChance) {
-        this.alleles.color = "a:b,b:b";
+        this.alleles.color = "a:C,b:C";
       } else if (rand < tanChance) {
-        this.alleles.color = Math.random() < 0.5 ? "a:B,b:b" : "a:b,b:B";
+        this.alleles.color = Math.random() < 0.5 ? "a:R,b:C" : "a:C,b:R";
       } else {
-        this.alleles.color = "a:B,b:B";
+        this.alleles.color = "a:R,b:R";
       }
       this.resetGeneticTraits();
     }


### PR DESCRIPTION
This change has no visible effect, as the allele names are not visible anywhere to the user. However, this makes it so it will be easy to use the correct allele names when we start showing them to the user.