### PR TITLE
Fix double-populations bug

### DIFF
--- a/src/components/spaces/populations/populations-container.tsx
+++ b/src/components/spaces/populations/populations-container.tsx
@@ -33,7 +33,7 @@ export class PopulationsComponent extends BaseComponent<IProps, IState> {
   public componentWillUnmount() {
     const populations = this.props.stores && this.props.stores.populations;
     if (populations) {
-      populations.pause();
+      populations.close();
     }
   }
 

--- a/src/components/spaces/populations/populations-container.tsx
+++ b/src/components/spaces/populations/populations-container.tsx
@@ -31,14 +31,11 @@ export class PopulationsComponent extends BaseComponent<IProps, IState> {
   }
 
   public componentWillUnmount() {
-    const populations = this.props.stores && this.props.stores.populations;
-    if (populations) {
-      populations.close();
-    }
+    this.stores.populations.close();
   }
 
   public render() {
-    const populations = this.props.stores && this.props.stores.populations;
+    const populations = this.stores.populations;
 
     if (populations && populations.interactive) {
       const buttons = populations.toolbarButtons.map( (button, i) => {
@@ -183,24 +180,15 @@ export class PopulationsComponent extends BaseComponent<IProps, IState> {
   }
 
   private handleClickRunButton = () => {
-    const populations = this.props.stores && this.props.stores.populations;
-    if (populations) {
-      populations.togglePlay();
-    }
+    this.stores.populations.togglePlay();
   }
 
   private handleClickInspectButton = () => {
-    const populations = this.props.stores && this.props.stores.populations;
-    if (populations) {
-      populations.toggleInteractionMode("inspect");
-    }
+    this.stores.populations.toggleInteractionMode("inspect");
   }
 
   private handleClickResetButton = () => {
-    const populations = this.props.stores && this.props.stores.populations;
-    if (populations) {
-      populations.reset();
-    }
+    this.stores.populations.reset();
   }
 
   private handleClickToolbarCheckbox = (button: ToolbarButton) => {
@@ -211,26 +199,21 @@ export class PopulationsComponent extends BaseComponent<IProps, IState> {
   }
 
   private handleClickSelect = () => {
-    const populations = this.props.stores && this.props.stores.populations;
-    if (populations) {
-      populations.toggleInteractionMode("select");
-    }
+    this.stores.populations.toggleInteractionMode("select");
   }
 
   private handleAgentClicked = (evt: AgentEnvironmentMouseEvent) => {
-    const populations = this.props.stores && this.props.stores.populations;
+    const populations = this.stores.populations;
     if (populations && populations.interactionMode === "select" && evt.type === "click" && evt.agents.mice) {
       const selectedMouse = evt.agents.mice;
-      if (this.props.stores) {
-        const backpack = this.props.stores.backpack;
-        const backpackMouse = BackpackMouse.create({
-          sex: selectedMouse.get("sex"),
-          genotype: (selectedMouse as any)._genomeButtonsString()
-        });
-        const added = backpack.addCollectedMouse(backpackMouse);
-        if (added){
-          this.props.stores.populations.removeAgent(selectedMouse);
-        }
+      const backpack = this.stores.backpack;
+      const backpackMouse = BackpackMouse.create({
+        sex: selectedMouse.get("sex"),
+        genotype: (selectedMouse as any)._genomeButtonsString()
+      });
+      const added = backpack.addCollectedMouse(backpackMouse);
+      if (added){
+        this.stores.populations.removeAgent(selectedMouse);
       }
     }
   }

--- a/src/models/spaces/populations/mouse-model/mouse-populations-model.ts
+++ b/src/models/spaces/populations/mouse-model/mouse-populations-model.ts
@@ -79,6 +79,12 @@ export const MousePopulationsModel = types
       }
     });
 
+    function clearGraph() {
+      self.chartData.dataSets[0].clearDataPoints();
+      self.chartData.dataSets[1].clearDataPoints();
+      self.chartData.dataSets[2].clearDataPoints();
+    }
+
     return {
       views: {
         get interactive(): HawksMiceInteractive {
@@ -111,9 +117,7 @@ export const MousePopulationsModel = types
           if (interactive) {
             interactive.reset();
           }
-          self.chartData.dataSets[0].clearDataPoints();
-          self.chartData.dataSets[1].clearDataPoints();
-          self.chartData.dataSets[2].clearDataPoints();
+          clearGraph();
         },
         setShowSexStack(show: boolean) {
           self.showSexStack = show;
@@ -123,6 +127,7 @@ export const MousePopulationsModel = types
         },
         destroyInteractive() {
           interactive = undefined;
+          clearGraph();
         }
       }
     };

--- a/src/models/spaces/populations/mouse-model/mouse-populations-model.ts
+++ b/src/models/spaces/populations/mouse-model/mouse-populations-model.ts
@@ -63,7 +63,7 @@ export const MousePopulationsModel = types
     "chartData": types.optional(ChartDataModel, chartData)
   })
   .extend(self => {
-    let interactive: HawksMiceInteractive;
+    let interactive: HawksMiceInteractive | undefined;
 
     function addData(time: number, datum: any) {
       self.chartData.dataSets[0].addDataPoint(time, datum.numWhite, "");
@@ -71,18 +71,23 @@ export const MousePopulationsModel = types
       self.chartData.dataSets[2].addDataPoint(time, datum.numBrown, "");
     }
     Events.addEventListener(Environment.EVENTS.STEP, () => {
-      const date = interactive.environment.date;
-      if (date % 5 === 0) {
-        addData(date / 5, interactive.getData());
+      if (interactive) {
+        const date = interactive.environment.date;
+        if (date % 5 === 0) {
+          addData(date / 5, interactive.getData());
+        }
       }
     });
 
     return {
       views: {
         get interactive(): HawksMiceInteractive {
-          // always recreate
-          interactive = createInteractive(self as MousePopulationsModelType);
-          return interactive;
+          if (interactive) {
+            return interactive;
+          } else {
+            interactive = createInteractive(self as MousePopulationsModelType);
+            return interactive;
+          }
         },
 
         get chanceOfMutation() {
@@ -103,7 +108,9 @@ export const MousePopulationsModel = types
           self["inheritance.breedWithInheritance"] = value;
         },
         reset() {
-          interactive.reset();
+          if (interactive) {
+            interactive.reset();
+          }
           self.chartData.dataSets[0].clearDataPoints();
           self.chartData.dataSets[1].clearDataPoints();
           self.chartData.dataSets[2].clearDataPoints();
@@ -113,6 +120,9 @@ export const MousePopulationsModel = types
         },
         setShowHeteroStack(show: boolean) {
           self.showHeteroStack = show;
+        },
+        destroyInteractive() {
+          interactive = undefined;
         }
       }
     };

--- a/src/models/spaces/populations/populations.ts
+++ b/src/models/spaces/populations/populations.ts
@@ -90,6 +90,10 @@ export const PopulationsModel = types
         },
         setRightPanel(val: RightPanelType) {
           self.rightPanel = val;
+        },
+        close() {
+          self.model.interactive.stop();
+          self.model.destroyInteractive();
         }
       }
     };


### PR DESCRIPTION
This reverts the changes in 8eab4b2e61, making it so that getting the
interactive from the mouse-populations model returns the existing
interactive if it is there (like before), but now adding an explicit
`close` method when the component is unmounted to destroy the existing
populations interactive.

[#162707041]