### PR TITLE
Add mystery labels

### DIFF
--- a/src/components/authoring.tsx
+++ b/src/components/authoring.tsx
@@ -146,7 +146,15 @@ const schema: JSONSchema6 = {
         instructions: {
           title: "Instructions (as markdown)",
           type: "string"
-        }
+        },
+        useMysteryOrganelles: {
+          title: "Show mystery location labels",
+          type: "boolean"
+        },
+        useMysterySubstances: {
+          title: "Show mystery substance labels",
+          type: "boolean"
+        },
       }
     }
   }
@@ -185,7 +193,9 @@ export const defaultAuthoring = {
     }
   },
   organism: {
-    instructions: ""
+    instructions: "",
+    useMysteryOrganelles: false,
+    useMysterySubstances: false
   }
 
 };

--- a/src/components/spaces/organisms/manipulation-controls.tsx
+++ b/src/components/spaces/organisms/manipulation-controls.tsx
@@ -16,6 +16,7 @@ interface IState {}
 export class ManipulationControls extends BaseComponent<IProps, IState> {
 
   public render() {
+    const {organisms} = this.stores;
     const row = this.getControlsRow();
     return (
       <div className="manipulation-controls" data-test="manipulations-panel">
@@ -42,10 +43,10 @@ export class ManipulationControls extends BaseComponent<IProps, IState> {
         </button>
         <select className={"organism-button select " + this.getButtonClass("add", ["cell", "protein"])}
                 value={row.selectedSubstance} onChange={this.handleSubstanceChange}>
-          <option value={"hormone"}>Hormone</option>
-          <option value={"pheomelanin"}>Pheomelanin</option>
-          <option value={"eumelanin"}>Eumelanin</option>
-          <option value={"signalProtein"}>Signal Protein</option>
+          <option value={"hormone"}>{organisms.getSubstanceLabel("hormone")}</option>
+          <option value={"pheomelanin"}>{organisms.getSubstanceLabel("pheomelanin")}</option>
+          <option value={"eumelanin"}>{organisms.getSubstanceLabel("eumelanin")}</option>
+          <option value={"signalProtein"}>{organisms.getSubstanceLabel("signalProtein")}</option>
         </select>
       </div>
     );

--- a/src/components/spaces/organisms/organelle-wrapper.sass
+++ b/src/components/spaces/organisms/organelle-wrapper.sass
@@ -1,3 +1,5 @@
+@import "../../vars"
+
 .model-wrapper
   position: relative
   cursor: default
@@ -11,13 +13,16 @@
 .hover-location
     position: absolute
     top: 45px
-    right: 5px
+    right: 0
     min-width: 94px
-    height: 18px
-    background: #FFFFFFAA
+    height: 23px
+    color: #fff
+    background: $color-simdata-carrot
     border: 1px solid #444
-    padding: 2px
+    padding: 2px 6px
     text-align: center
-
+    border: 2px solid #fff
+    border-right: none
+    border-radius: 0 0 0 5px
 .temp-dropper
   position: absolute

--- a/src/components/spaces/organisms/organelle-wrapper.tsx
+++ b/src/components/spaces/organisms/organelle-wrapper.tsx
@@ -228,10 +228,11 @@ export class OrganelleWrapper extends BaseComponent<OrganelleWrapperProps, Organ
   public render() {
     const {organisms} = this.stores;
     const {mode} = this.props;
+    const {getOrganelleLabel} = organisms;
     // const hoverLabel = appStore.mysteryLabels ?
     //   mysteryOrganelleNames[this.state.hoveredOrganelle] : this.state.hoveredOrganelle;
     const hoveredOrganelle = organisms.rows[this.props.rowIndex].hoveredOrganelle;
-    const hoverLabel = hoveredOrganelle ? kOrganelleInfo[hoveredOrganelle].displayName : undefined;
+    const hoverLabel = hoveredOrganelle ? getOrganelleLabel(hoveredOrganelle) : undefined;
     const hoverDiv = hoverLabel
       ? (
         <div className="hover-location" data-test="hover-label">

--- a/src/models/spaces/organisms/organisms-row.ts
+++ b/src/models/spaces/organisms/organisms-row.ts
@@ -38,7 +38,9 @@ export const OrganismsRowModel = types
         organelleLabels.push(organelleLabel);
       });
       kSubstanceNames.forEach((substance, index) => {
-        const substanceName: string = kSubstanceInfo[substance].displayName;
+        const substanceName: string = organisms
+          ? organisms.getSubstanceLabel(substance)
+          : kSubstanceInfo[substance].displayName;
         const substanceColor: string =  kSubstanceInfo[substance].color;
         const points: DataPointType[] = [];
         self.assayedOrganelles.forEach((organelle) => {

--- a/src/models/spaces/organisms/organisms-row.ts
+++ b/src/models/spaces/organisms/organisms-row.ts
@@ -1,10 +1,10 @@
-import { types, Instance } from "mobx-state-tree";
+import { types, Instance, getParentOfType } from "mobx-state-tree";
 import { ChartDataModelType, ChartDataModel } from "../charts/chart-data";
 import { RightPanelTypeEnum, RightPanelType } from "../../ui";
 import { DataPoint, ChartDataSetModel, DataPointType, ChartDataSetModelType } from "../charts/chart-data-set";
 import { OrganismsMouseModel, Organelle, Substance, kSubstanceNames,
   OrganelleType, SubstanceType } from "./organisms-mouse";
-import { kSubstanceInfo } from "./organisms-space";
+import { kSubstanceInfo, OrganismsSpaceModel, OrganismsSpaceModelType, kOrganelleInfo } from "./organisms-space";
 
 export const Mode = types.enumeration("type", ["add", "subtract", "assay", "inspect", "normal"]);
 export type ModeType = typeof Mode.Type;
@@ -31,8 +31,11 @@ export const OrganismsRowModel = types
       const chartDataSets: ChartDataSetModelType[] = [];
       const organelleLabels: string[] = [];
 
+      const organisms = getParentOfType(self, OrganismsSpaceModel);
+
       self.assayedOrganelles.forEach((organelle) => {
-        organelleLabels.push(organelle);
+        const organelleLabel = organisms ? organisms.getOrganelleLabel(organelle) : organelle;
+        organelleLabels.push(organelleLabel);
       });
       kSubstanceNames.forEach((substance, index) => {
         const substanceName: string = kSubstanceInfo[substance].displayName;
@@ -43,7 +46,8 @@ export const OrganismsRowModel = types
             return;
           }
           const substanceValue = self.organismsMouse.getSubstanceValue(organelle, substance);
-          points.push(DataPoint.create({ a1: substanceValue, a2: 0, label: `${organelle} ${substanceName}` }));
+          const organelleLabel = organisms ? organisms.getOrganelleLabel(organelle) : organelle;
+          points.push(DataPoint.create({ a1: substanceValue, a2: 0, label: `${organelleLabel} ${substanceName}` }));
         });
         const stackNum = "Stack " + index;
         chartDataSets.push(ChartDataSetModel.create({

--- a/src/models/spaces/organisms/organisms-space.test.ts
+++ b/src/models/spaces/organisms/organisms-space.test.ts
@@ -1,0 +1,41 @@
+import { OrganismsSpaceModel, OrganismsSpaceModelType } from "./organisms-space";
+import { destroy, detach } from "mobx-state-tree";
+
+describe("Organisms Space model", () => {
+  let organisms: OrganismsSpaceModelType;
+
+  describe("without mystery labels", () => {
+    beforeEach(() => {
+      organisms = OrganismsSpaceModel.create({
+        rows: []    // if we don't blank rows, we can't create this twice. Don't ask why...
+      });
+    });
+
+    it("has default labels for substances", () => {
+      expect(organisms.getSubstanceLabel("pheomelanin")).toEqual("pheomelanin");
+    });
+
+    it("has default labels for organelles", () => {
+      expect(organisms.getOrganelleLabel("nucleus")).toEqual("Nucleus");
+    });
+  });
+
+  describe("with mystery labels", () => {
+    let organisms2: OrganismsSpaceModelType;
+    beforeEach(() => {
+      organisms2 = OrganismsSpaceModel.create({
+        rows: [],
+        useMysteryOrganelles: true,
+        useMysterySubstances: true
+      });
+    });
+
+    it("has default labels for substances", () => {
+      expect(organisms2.getSubstanceLabel("pheomelanin")).toEqual("substance A");
+    });
+
+    it("has default labels for organelles", () => {
+      expect(organisms2.getOrganelleLabel("nucleus")).toEqual("Location 2");
+    });
+  });
+});

--- a/src/models/spaces/organisms/organisms-space.ts
+++ b/src/models/spaces/organisms/organisms-space.ts
@@ -9,24 +9,29 @@ import { OrganismsRowModel } from "./organisms-row";
 type SubstanceInfo = {
   [substance in SubstanceType]: {
     displayName: string;
+    mysteryLabel: string;
     color: string;
   };
 };
 export const kSubstanceInfo: SubstanceInfo = {
   pheomelanin: {
     displayName: "pheomelanin",
+    mysteryLabel: "substance A",
     color: "#f4ce83"
   },
   signalProtein: {
     displayName: "signal protein",
+    mysteryLabel: "substance B",
     color: "#d88bff"
   },
   eumelanin: {
     displayName: "eumelanin",
+    mysteryLabel: "substance C",
     color: "#795423"
   },
   hormone: {
     displayName: "hormone",
+    mysteryLabel: "substance D",
     color: "#0adbd7"
   },
 };
@@ -130,6 +135,7 @@ export const OrganismsSpaceModel = types
     rows: types.optional(types.array(OrganismsRowModel),
       [OrganismsRowModel.create(), OrganismsRowModel.create({rightPanel: "data"})]),
     useMysteryOrganelles: false,
+    useMysterySubstances: false,
     instructions: ""
   })
   .views(self => {
@@ -139,6 +145,12 @@ export const OrganismsSpaceModel = types
           return kOrganelleInfo[organelle].mysteryLabel;
         }
         return kOrganelleInfo[organelle].displayName;
+      },
+      getSubstanceLabel(substance: SubstanceType) {
+        if (self.useMysterySubstances) {
+          return kSubstanceInfo[substance].mysteryLabel;
+        }
+        return kSubstanceInfo[substance].displayName;
       }
     };
   })

--- a/src/models/spaces/organisms/organisms-space.ts
+++ b/src/models/spaces/organisms/organisms-space.ts
@@ -34,6 +34,7 @@ export const kSubstanceInfo: SubstanceInfo = {
 type OrganelleInfo = {
   [organelle in OrganelleType]: {
     displayName: string;
+    mysteryLabel: string;
     substances: {
       [substance in SubstanceType]?: {
         [color in ColorType]: number;
@@ -48,10 +49,12 @@ type OrganelleInfo = {
 export const kOrganelleInfo: OrganelleInfo = {
   nucleus: {
     displayName: "Nucleus",
+    mysteryLabel: "Location 2",
     substances: {}
   },
   cytoplasm: {
     displayName: "Cytoplasm",
+    mysteryLabel: "Location 3",
     substances: {
       signalProtein: {
         white: 0,
@@ -62,10 +65,12 @@ export const kOrganelleInfo: OrganelleInfo = {
   },
   golgi: {
     displayName: "Golgi",
+    mysteryLabel: "",
     substances: {}
   },
   extracellular: {
     displayName: "Extracellular",
+    mysteryLabel: "Location 4",
     substances: {
       hormone: {
         white: 125,
@@ -76,6 +81,7 @@ export const kOrganelleInfo: OrganelleInfo = {
   },
   melanosome: {
     displayName: "Melanosome",
+    mysteryLabel: "Location 1",
     substances: {
       eumelanin: {
         white: 0,
@@ -91,24 +97,29 @@ export const kOrganelleInfo: OrganelleInfo = {
   },
   receptor: {
     displayName: "Receptor",
+    mysteryLabel: "",
     substances: {}
   },
   receptorWorking: {
     displayName: "Receptor",
+    mysteryLabel: "",
     substances: {},
     protein: MouseProteins.receptor.working
   },
   receptorBroken: {
     displayName: "Receptor",
+    mysteryLabel: "",
     substances: {},
     protein: MouseProteins.receptor.broken
   },
   gate: {
     displayName: "Gate",
+    mysteryLabel: "",
     substances: {}
   },
   nearbyCell: {
     displayName: "Nearby Cell",
+    mysteryLabel: "Location 5",
     substances: {}
   },
 };
@@ -118,7 +129,18 @@ export const OrganismsSpaceModel = types
     organismsMice: types.array(OrganismsMouseModel),
     rows: types.optional(types.array(OrganismsRowModel),
       [OrganismsRowModel.create(), OrganismsRowModel.create({rightPanel: "data"})]),
+    useMysteryOrganelles: false,
     instructions: ""
+  })
+  .views(self => {
+    return {
+      getOrganelleLabel(organelle: OrganelleType) {
+        if (self.useMysteryOrganelles) {
+          return kOrganelleInfo[organelle].mysteryLabel;
+        }
+        return kOrganelleInfo[organelle].displayName;
+      }
+    };
   })
   .actions((self) => {
     function clearRowBackpackMouse(rowIndex: number) {

--- a/src/models/stores.ts
+++ b/src/models/stores.ts
@@ -33,6 +33,6 @@ export function createStores(params: ICreateStores, authoring: any): IStores {
     backpack: params && params.backpack
       || BackpackModel.create({}),
     organisms: params && params.organisms ||
-      OrganismsSpaceModel.create({instructions: authoring.organism.instructions})
+      OrganismsSpaceModel.create(authoring.organism)
   };
 }


### PR DESCRIPTION
This adds simple props for using or not using the mystery labels for organelles and substances. All view requests for the strings now go through a method in the organismsSpace model.

Adds a quick test, which would be uninteresting except that it exposes an odd MST behavior that we can't create more than one `OrganismsSpaceModel`, as we do in a test's `beforeEach` method, without MobX complaining that we are trying to create two of the same object, specifically not the `OrganismsSpaceModel` but the first `OrganismsRowModel` of each.

That is, the following code
 
    const model1 = OrganismsSpaceModel.create({});
    const model2 = OrganismsSpaceModel.create({});   // even with some other properties

throws

    [mobx-state-tree] Cannot add an object to a state tree if it is already part of the
    same another state tree. Tried to assign an object to '/rows/0', but it lives already
    at '/rows/0'

This could only be resolved by explicitly creating `OrganismsSpaceModels` with no rows.

Maybe @ekosmin has thoughts, but you don't need to spend time looking at it, it's just worth noting if it crops up again.