### PR TITLE
Insure we never get wrong mouse color population, reduce population when in wrong environment

### DIFF
--- a/src/models/spaces/populations/mouse-model/hawks-mice-interactive.ts
+++ b/src/models/spaces/populations/mouse-model/hawks-mice-interactive.ts
@@ -275,14 +275,32 @@ export function createInteractive(model: MousePopulationsModelType) {
       }
     }
 
+    // Insurance: Ensure there are always at least two rabbits of the correct color.
+    // We need to catch it before there are zero. Once there are zero, we can't create any out
+    // of thin air. (E.g. user eliminated one population then changed environment)
+    if (environmentColor === "white" && numWhite > 1 && numWhite < 3) {
+      for (let i = 0; i < 2; i++) {
+        addAgent(mouseSpecies, [], [createColorTraitByGenotype("a:C,b:C")]);
+      }
+    } else if (environmentColor === "neutral" && numTan > 1 && numTan < 3) {
+      for (let i = 0; i < 2; i++) {
+        addAgent(mouseSpecies, [], [createColorTraitByGenotype("a:C,b:R")]);
+      }
+    } else if (environmentColor === "brown" && numBrown > 1 && numBrown < 3) {
+      for (let i = 0; i < 2; i++) {
+        addAgent(mouseSpecies, [], [createColorTraitByGenotype("a:R,b:R")]);
+      }
+    }
+
     // Reproduction rates go to zero when the population reaches a 'carrying capacity' of 50
     setProperty(allMice, "mating chance", -.005 * numMice + .25);
 
-    if (this.addedMice && addedHawks) {
+    // If there is only one color left, and it is the "wrong" color, reduce carrying capacity
+    if (addedHawks && (numBrown === numMice || numWhite === numMice)) {
       allMice.forEach((mouse) => {
         if (mouse.get("color") !== environmentColor) {
           // Reduce the carrying capacity to 10 if mice are vulnerable to a predator
-          mouse.set("mating chance", -.025 * this.numMice + .25);
+          mouse.set("mating chance", -.025 * numMice + .25);
         }
       });
     }


### PR DESCRIPTION
Previously we were seeing occasional "wrong" mice populations, e.g. all brown mice with hawks in white environment.

This seemed to be being caused by:

1. Limited vertical movement (this has since been fixed)
2. Bugs in code that was supposed to reduce "wrong" color's mating chance.

The mating chance code has been fixed, but it seemed too powerful to run all the time. Now it just runs if the user eliminates one population and then switches environments.

With the fixed vertical movement, we generally don't get wrong results, but this also adds a bit of insurance to make sure we never eliminate the wrong population.

[#163911808]