### PR TITLE
162622045 graph button styling

### DIFF
--- a/src/components/two-up-display.sass
+++ b/src/components/two-up-display.sass
@@ -16,6 +16,19 @@
   margin: $double-two-up-margin
   overflow: hidden
 
+  .button-holder
+    flex-grow: 0
+    flex-shrink: 0
+    display: flex
+    align-items: center
+    justify-content: center
+    height: 30px
+    &:hover:not(.disabled)
+      cursor: pointer
+    &.disabled
+      opacity: .5
+      pointer-events: none
+
   .header
     flex: 0 0 $two-up-header-height
     display: flex
@@ -25,10 +38,8 @@
     text-align: center
     background-color: $two-up-header-bgcolor
     margin-bottom: 2px
-
     &.populations
       background-color: $color-simdata-amber
-
     &.organism
       background-color: $color-simdata-carrot
 
@@ -36,29 +47,13 @@
       flex-grow: 1
 
     .button-holder
-      flex-grow: 0
-      flex-shrink: 0
-      display: flex
-      align-items: center
-      justify-content: center
       width: 30px
-      height: 30px
-
       &:hover:not(.disabled)
         background-color: $two-up-button-background
-        cursor: pointer
-
       .button
         height: $two-up-button-icon-height
         width: $two-up-button-icon-width
         fill: $color-simdata-amber-light1
-      &.active
-        .button
-          fill: $two-up-button-icon-color-active
-
-      &.disabled
-        .button
-          opacity: 0.25
       &.active
         .button
           fill: $two-up-button-icon-color-active
@@ -94,42 +89,55 @@
     display: flex
     align-items: center
     justify-content: center
-    flex: 0 0 $two-up-footer-height
+    height: $two-up-footer-height
     width: 100%
+    margin-top: 2px
     background-color: $two-up-header-bgcolor
     border-bottom-left-radius: $component-border-radius
     border-bottom-right-radius: $component-border-radius
+    transition-property: height
+    transition-duration: $fade-time
 
     &.populations
       background-color: $color-simdata-amber
+    &.data
+      height: 45px
 
     &.organism
       background-color: $color-simdata-carrot
 
     .button-holder
-      flex-grow: 0
-      flex-shrink: 0
-      display: flex
-      align-items: center
-      justify-content: center
       width: 140px
-      height: 30px
       border-radius: 13px
       font-size: 11px
       font-family: $font-stack
       color: $color-simdata-amber-dark2
       background-color: $color-simdata-amber-light2
-      cursor: pointer
       transition-duration: $fade-time
-      &:hover
+      &:hover:not(.disabled)
         background-color: $color-simdata-amber-light1
-      &:active
+      &:active:not(.disabled)
         background-color: $color-simdata-amber-dark1
         color: $color-white
-      &.disabled
-        opacity: .5
-        pointer-events: none
 
+  .float-buttons
+    .button-holder
+      position: absolute
+      top: 111px
+      right: 17px
+      width: 114px
+      height: 29px
+      border-radius: 5px
+      font-size: 11px
+      font-family: $font-stack
+      color: $color-simdata-amber-dark2
+      background-color: $color-simdata-amber-light2
+      transition-duration: $fade-time
+      &:hover:not(.disabled)
+        background-color: $color-simdata-amber-light1
+      &:active:not(.disabled)
+        background-color: $color-simdata-amber-dark1
+        color: $color-white
 
 .left-abutment
   margin-left: $two-up-margin

--- a/src/components/two-up-display.sass
+++ b/src/components/two-up-display.sass
@@ -22,7 +22,12 @@
     display: flex
     align-items: center
     justify-content: center
+    width: 30px
     height: 30px
+    font-size: 11px
+    font-family: $font-stack
+    color: $color-simdata-amber-dark2
+    transition-duration: $fade-time
     &:hover:not(.disabled)
       cursor: pointer
     &.disabled
@@ -47,7 +52,6 @@
       flex-grow: 1
 
     .button-holder
-      width: 30px
       &:hover:not(.disabled)
         background-color: $two-up-button-background
       .button
@@ -97,23 +101,17 @@
     border-bottom-right-radius: $component-border-radius
     transition-property: height
     transition-duration: $fade-time
-
     &.populations
       background-color: $color-simdata-amber
     &.data
       height: 45px
-
     &.organism
       background-color: $color-simdata-carrot
 
     .button-holder
       width: 140px
       border-radius: 13px
-      font-size: 11px
-      font-family: $font-stack
-      color: $color-simdata-amber-dark2
       background-color: $color-simdata-amber-light2
-      transition-duration: $fade-time
       &:hover:not(.disabled)
         background-color: $color-simdata-amber-light1
       &:active:not(.disabled)
@@ -123,16 +121,13 @@
   .float-buttons
     .button-holder
       position: absolute
-      top: 111px
-      right: 17px
       width: 114px
       height: 29px
       border-radius: 5px
-      font-size: 11px
-      font-family: $font-stack
-      color: $color-simdata-amber-dark2
       background-color: $color-simdata-amber-light2
-      transition-duration: $fade-time
+      &.upper-right
+        top: 111px
+        right: 17px
       &:hover:not(.disabled)
         background-color: $color-simdata-amber-light1
       &:active:not(.disabled)

--- a/src/components/two-up-display.tsx
+++ b/src/components/two-up-display.tsx
@@ -93,23 +93,49 @@ export class TwoUpDisplayComponent extends BaseComponent<IProps, IState> {
           {this.props.rightPanel}
         </div>
         {this.renderRightPanelFooter()}
+        {this.renderFloatButtons()}
       </div>
     );
   }
 
-  private renderRightPanelFooter(){
-    if (this.props.spaceClass === "populations" &&
-        this.props.selectedRightPanel === "data" &&
-        this.props.rightPanelButtons) {
-      const buttons = this.props.rightPanelButtons.map( (button: any) => {
+  private renderRightPanelFooter() {
+    if (this.props.rightPanelButtons) {
+      let buttons = null;
+      buttons = this.props.rightPanelButtons.map( (button: any) => {
         const type = button.type || "button";
-        let title = button.title;
-        if (button.title === "Scale") {
-          title = button.value ? "Show Recent Data" : "Show All Data";
-        }
-        if (type === "button") {
+        if (type === "button" && this.props.selectedRightPanel === button.section) {
           return (
             <div key={button.title} className="button-holder" onClick={button.action}>
+              {button.title}
+            </div>
+          );
+        }
+      });
+      const footerClass = "footer " + this.props.spaceClass + " " + this.props.selectedRightPanel;
+      return (
+        <div className={footerClass} data-test="right-footer">
+          { buttons ? buttons : null }
+        </div>
+      );
+    } else {
+      return null;
+    }
+
+  }
+
+  private renderFloatButtons() {
+    if (this.props.rightPanelButtons) {
+      let buttons = null;
+      buttons = this.props.rightPanelButtons.map( (button: any) => {
+        const type = button.type || "button";
+        if (type === "float-button" && this.props.selectedRightPanel === button.section) {
+          let title = button.title;
+          if (button.title === "Scale") {
+            title = button.value ? "Show Recent Data" : "Show All Data";
+          }
+          const buttonClass = "button-holder " + type + " " + button.floatCorner;
+          return (
+            <div key={button.title} className={buttonClass} onClick={button.action}>
               {title}
             </div>
           );
@@ -117,14 +143,13 @@ export class TwoUpDisplayComponent extends BaseComponent<IProps, IState> {
       });
 
       return (
-        <div className={"footer " + this.props.spaceClass} data-test="right-footer">
-          { buttons }
+        <div className="float-buttons" data-test="right-float-buttons">
+          { buttons ? buttons : null }
         </div>
       );
     } else {
       return null;
     }
-
   }
 
   private handleClickRightIcon = (icon: RightPanelType, enabled?: boolean) => {

--- a/src/components/vars.sass
+++ b/src/components/vars.sass
@@ -231,7 +231,7 @@ $collect-button-icon-height: 45px
 // two-up display
 //
 $two-up-header-height: 30px
-$two-up-footer-height: 60px
+$two-up-footer-height: 30px
 $two-up-header-color: $color-white
 $two-up-header-bgcolor: $color-simdata-amber
 $two-up-button-background: $color-simdata-amber-dark1

--- a/src/models/spaces/populations/mouse-model/mouse-populations-model.ts
+++ b/src/models/spaces/populations/mouse-model/mouse-populations-model.ts
@@ -226,10 +226,13 @@ export const MousePopulationsModel = types
 
           buttons.push({
             title: "Scale",
+            type: "float-button",
             value: self.showMaxPoints,
             action: (val: boolean) => {
               self.toggleShowMaxPoints();
-            }
+            },
+            floatCorner: "upper-right",
+            section: "data"
           });
 
           return buttons;

--- a/src/models/spaces/populations/populations.ts
+++ b/src/models/spaces/populations/populations.ts
@@ -29,6 +29,8 @@ export interface ToolbarButton {
   value?: boolean;
   action: (e: (React.MouseEvent<HTMLButtonElement> | boolean)) => void;
   enabled?: boolean;
+  floatCorner?: string;
+  section?: string;
 }
 
 const InteractionModeEnum = types.enumeration("interaction", ["none", "select", "inspect"]);


### PR DESCRIPTION
Add styling to the show all/show recent graph data button.  This required some refactoring as this button needed to be shown in the upper-right corner, not in the toolbar.  I still like the idea of having an array of `rightPanelButtons` that we build on a per space basis.  However, some extra tweaking was required to specify how to place a button like the show all/show recent button that gets placed somewhere outside of the toolbar.  For now, I was thinking of these as floating buttons - buttons that float somewhere in the panel which would be determined by a CSS class tied to each button.  Obviously lots of ways of doing this, and I'm not eager to make an unusual case to handle a single button, but I was assuming something like this will probably come up again.