### PR TITLE
Optimize graph when all data is displayed

### DIFF
--- a/src/components/charts/line-chart-controls.tsx
+++ b/src/components/charts/line-chart-controls.tsx
@@ -49,7 +49,7 @@ export class LineChartControls extends BaseComponent<IChartControlProps, IChartC
     const { chartData, isPlaying } = this.props;
     const { scrubberPosition, scrubberMin, scrubberMax } = this.state;
     const pos = scrubberPosition ? scrubberPosition : 0;
-    const timelineVisible = chartData.pointCount > chartData.maxPoints;
+    const timelineVisible = chartData.maxPoints > 0 && chartData.pointCount > chartData.maxPoints;
 
     const trackStyle = { backgroundColor: colors.chartColor5, height: 10 };
     const handleStyle = {

--- a/src/components/charts/line-chart.tsx
+++ b/src/components/charts/line-chart.tsx
@@ -107,6 +107,9 @@ const lineData = (chartData: ChartDataModelType) => {
     if (d.visibleDataPoints.length >= 80) {
       dset.lineTension = 0;
     }
+
+    dset.dataPoints = d.visibleDataPoints;
+
     lineDatasets.push(dset);
   }
 

--- a/src/components/charts/line-chart.tsx
+++ b/src/components/charts/line-chart.tsx
@@ -103,6 +103,10 @@ const lineData = (chartData: ChartDataModelType) => {
       dset.minRotation = d.fixedLabelRotation;
       dset.maxRotation = d.fixedLabelRotation;
     }
+    // optimize rendering
+    if (d.visibleDataPoints.length >= 80) {
+      dset.lineTension = 0;
+    }
     lineDatasets.push(dset);
   }
 

--- a/src/models/spaces/charts/chart-data-set.ts
+++ b/src/models/spaces/charts/chart-data-set.ts
@@ -86,7 +86,16 @@ export const ChartDataSetModel = types
     dataStartIdx: types.maybe(types.number),
     stack: types.maybe(types.string),
     axisLabelA1: types.maybe(types.string),
-    axisLabelA2: types.maybe(types.string)
+    axisLabelA2: types.maybe(types.string),
+    // Sets whether we start downsampling the data after a certain number of points, for performant live data
+    downsample: true,
+    // The maximum points the visible data will ever contain, if we downsample
+    downsampleMaxLength: 120,
+    // For live data, we may not want to downsample the data every step, or we'll see the past data points constantly
+    // changing. Rather, we downsample all the data up to a certain point, then add growWindow more points as-is,
+    // and then resample the entire set and start again.
+    // In order to always downsample the entire dataset (e.g. for static data), set downsampleGrowWindow: 1.
+    downsampleGrowWindow: 40
   })
   .views(self => ({
     get visibleDataPoints() {
@@ -107,11 +116,12 @@ export const ChartDataSetModel = types
       // We could just always downsample to MAX_TOTAL_POINTS, but that results in the points changing every
       // tick, which is visually annoying, so instead we downsample up to MAX_TOTAL_POINTS - GROW_WINDOW, and
       // then add on the remainder as-is, and then downsample again when we grow past our window
-      if (points.length > (MAX_TOTAL_POINTS - GROW_WINDOW)) {
-        const grow = points.length % GROW_WINDOW;
-        const dataToSample = self.dataPoints.slice(0, points.length - grow);
-        const sampledData = downsample(dataToSample, (MAX_TOTAL_POINTS - GROW_WINDOW));
-        points = grow ? sampledData.concat(points.slice(-grow)) : sampledData;
+      const {downsampleMaxLength: max, downsampleGrowWindow: growWindow} = self;
+      if (self.downsample && points.length > (max - growWindow)) {
+        const tailLength = points.length % growWindow;
+        const dataToSample = self.dataPoints.slice(0, points.length - tailLength);
+        const sampledData = downsample(dataToSample, (max - growWindow));
+        points = tailLength ? sampledData.concat(points.slice(-tailLength)) : sampledData;
       }
       return points;
     }

--- a/src/models/spaces/charts/chart-data.test.ts
+++ b/src/models/spaces/charts/chart-data.test.ts
@@ -95,4 +95,55 @@ describe("chart data model", () => {
     expect(chart.dataSets[0].dataA2[0]).toEqual(70);
     expect(chart.dataSets[0].dataA1[2]).toBeUndefined();
   });
+
+  it("can truncate its visible data", () => {
+    chart.dataSets[0].addDataPoint(65, 75, "delta");
+    chart.dataSets[0].addDataPoint(70, 85, "echo");
+    chart.dataSets[0].addDataPoint(75, 80, "foxtrot");
+
+    chart.dataSets[0].setMaxDataPoints(2);
+
+    expect(chart.dataSets[0].dataPoints.length).toEqual(6);
+    expect(chart.dataSets[0].visibleDataPoints.length).toEqual(2);
+    expect(chart.dataSets[0].minA1).toEqual(70);
+    expect(chart.dataSets[0].maxA1).toEqual(75);
+  });
+
+  it("can show all visible data", () => {
+    chart.dataSets[0].addDataPoint(65, 75, "delta");
+    chart.dataSets[0].addDataPoint(70, 85, "echo");
+    chart.dataSets[0].addDataPoint(75, 80, "foxtrot");
+
+    chart.dataSets[0].setMaxDataPoints(-1);
+
+    expect(chart.dataSets[0].dataPoints.length).toEqual(6);
+    expect(chart.dataSets[0].visibleDataPoints.length).toEqual(6);
+    expect(chart.dataSets[0].minA1).toEqual(0);
+    expect(chart.dataSets[0].maxA1).toEqual(75);
+  });
+
+  // assumes MAX_TOTAL_POINTS = 120, GROW_WINDOW = 40. If these change, we
+  // should add a setter.
+  it.only("can downsample its visible data", () => {
+    chart.dataSets[0].setMaxDataPoints(-1);
+
+    for (let i = 0; i < 200; i++) {
+      chart.dataSets[0].addDataPoint(i, 100 + i, "");
+    }
+
+    expect(chart.dataSets[0].dataPoints.length).toEqual(203);
+    expect(chart.dataSets[0].visibleDataPoints.length).toEqual(83);   // 80 downsampled points and 3 additional
+
+    for (let i = 0; i < 36; i++) {
+      chart.dataSets[0].addDataPoint(i, 300 + i, "");
+    }
+
+    expect(chart.dataSets[0].dataPoints.length).toEqual(239);
+    expect(chart.dataSets[0].visibleDataPoints.length).toEqual(119);   // 80 downsampled points and 39 additional
+
+    chart.dataSets[0].addDataPoint(0, 400, "");
+
+    expect(chart.dataSets[0].dataPoints.length).toEqual(240);
+    expect(chart.dataSets[0].visibleDataPoints.length).toEqual(80);   // 80 downsampled points
+  });
 });

--- a/src/models/spaces/charts/chart-data.test.ts
+++ b/src/models/spaces/charts/chart-data.test.ts
@@ -15,7 +15,10 @@ describe("chart data model", () => {
       name: "Sample Dataset1",
       dataPoints: points,
       color: "#ff0000",
-      maxPoints: 100
+      maxPoints: 100,
+      downsample: true,
+      downsampleMaxLength: 120,
+      downsampleGrowWindow: 40
     }));
 
     chart = ChartDataModel.create({
@@ -122,8 +125,6 @@ describe("chart data model", () => {
     expect(chart.dataSets[0].maxA1).toEqual(75);
   });
 
-  // assumes MAX_TOTAL_POINTS = 120, GROW_WINDOW = 40. If these change, we
-  // should add a setter.
   it.only("can downsample its visible data", () => {
     chart.dataSets[0].setMaxDataPoints(-1);
 

--- a/src/models/spaces/populations/mouse-model/mouse-populations-model.ts
+++ b/src/models/spaces/populations/mouse-model/mouse-populations-model.ts
@@ -79,14 +79,11 @@ export const MousePopulationsModel = types
       self.chartData.dataSets[0].addDataPoint(time, datum.numWhite, "");
       self.chartData.dataSets[1].addDataPoint(time, datum.numTan, "");
       self.chartData.dataSets[2].addDataPoint(time, datum.numBrown, "");
-      if (self.showMaxPoints) {
-        displayMaxPoints();
-      }
     }
 
     function displayMaxPoints() {
       self.chartData.dataSets.forEach((dataSet: any) => {
-        dataSet.setMaxDataPoints(dataSet.dataPoints.length);
+        dataSet.setMaxDataPoints(-1);
       });
     }
     function displayRecentPoints() {

--- a/src/utilities/data.ts
+++ b/src/utilities/data.ts
@@ -1,0 +1,44 @@
+import { DataPointType } from "../models/spaces/charts/chart-data-set";
+
+/**
+ * Downsample using Largest Triangle, One Bucket method.
+ * See https://blog.scottlogic.com/2015/11/16/sampling-large-data-in-d3fc.html
+ */
+export function downsample(points: DataPointType[], maxSize: number) {
+  const length = points.length;
+  if (maxSize >= length) return points;
+  if (maxSize < 1 || length < 1) return [];
+
+  const bucketSize = length / maxSize;
+
+  const sampledData = [points[0]];
+
+  for (let bucket = 1; bucket < maxSize - 1; bucket++) {
+    const startIndex = Math.floor(bucket * bucketSize);
+    const endIndex = Math.min(length - 1, (bucket + 1) * bucketSize);
+
+    let maxArea = -1;
+    let maxAreaIndex = -1;
+    for (let j = startIndex; j < endIndex; j++) {
+      const previousDataPoint = points[j - 1];
+      const dataPoint = points[j];
+      const nextDataPoint = points[j + 1];
+
+      const area = calculateTriangleArea(previousDataPoint, dataPoint, nextDataPoint);
+      if (area > maxArea) {
+        maxArea = area;
+        maxAreaIndex = j;
+      }
+    }
+
+    sampledData.push(points[maxAreaIndex]);
+  }
+
+  sampledData.push(points[length - 1]);
+
+  return sampledData;
+}
+
+function calculateTriangleArea(a: DataPointType, b: DataPointType, c: DataPointType) {
+  return Math.abs((a.a1 - c.a1) * (b.a2 - a.a2) - (a.a1 - b.a1) * (c.a2 - a.a2)) / 2;
+}


### PR DESCRIPTION
This downsamples the datapoints displayed by the chart using a downsampling algorithm, [largest triangle one bucket](https://blog.scottlogic.com/2015/11/16/sampling-large-data-in-d3fc.html),	which attempts to preserve major features of the data.

This downsamples the entire dataset every 40 datapoints, and then streams the next 40 points as-is. This avoids downsampling every tick, which causes the data to change every tick, which is visually jarring.

Because the sampled dataset doesn't change over the 40 point window, we could cache it as a further optimization, but the actual sampling is very fast, and so this doesn't seem worth the complications.

This also adds an additional rendering optimization of removing the line tension (smoothing) when we have too many datapoints.