### PR TITLE
Add graph axes labels and scale for weeks

### DIFF
--- a/src/components/charts/line-chart.tsx
+++ b/src/components/charts/line-chart.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { Scatter, ChartData } from "react-chartjs-2";
 import { observer } from "mobx-react";
+import { merge } from "lodash";
 import { ChartDataModelType } from "../../models/spaces/charts/chart-data";
 import { ChartOptions } from "chart.js";
 import { ChartColors } from "../../models/spaces/charts/chart-data-set";
@@ -37,10 +38,14 @@ const defaultOptions: ChartOptions = {
       ticks: {
         min: 0,
         max: 100
+      },
+      scaleLabel: {
+        display: true,
+        fontSize: 12
       }
     }],
     xAxes: [{
-      display: false,
+      display: true,
       ticks: {
         min: 0,
         max: 20
@@ -120,24 +125,18 @@ export class LineChart extends BaseComponent<ILineProps, ILineState> {
     const chartDisplay = lineData(chartData);
     const graphs: JSX.Element[] = [];
     const minMaxValues = chartData.minMaxAll;
-    const options: ChartOptions = Object.assign({}, defaultOptions, {
+    const options: ChartOptions = merge({}, defaultOptions, {
       title: {
         text: chartData.name
       },
       scales: {
-        display: false,
         yAxes: [{
           ticks: {
             min: minMaxValues.minA2,
             max: minMaxValues.maxA2
-          },
-          scaleLabel: {
-            display: true,
-            fontSize: 12
           }
         }],
         xAxes: [{
-          display: true,
           ticks: {
             min: minMaxValues.minA1,
             max: minMaxValues.maxA1,

--- a/src/components/charts/line-chart.tsx
+++ b/src/components/charts/line-chart.tsx
@@ -134,6 +134,10 @@ export class LineChart extends BaseComponent<ILineProps, ILineState> {
           ticks: {
             min: minMaxValues.minA2,
             max: minMaxValues.maxA2
+          },
+          scaleLabel: {
+            display: !!chartData.axisLabelA2,
+            labelString: chartData.axisLabelA2
           }
         }],
         xAxes: [{
@@ -142,6 +146,10 @@ export class LineChart extends BaseComponent<ILineProps, ILineState> {
             max: minMaxValues.maxA1,
             minRotation: chartData.dataLabelRotation,
             maxRotation: chartData.dataLabelRotation
+          },
+          scaleLabel: {
+            display: !!chartData.axisLabelA1,
+            labelString: chartData.axisLabelA1
           }
         }]
       }

--- a/src/models/spaces/charts/chart-data-set.ts
+++ b/src/models/spaces/charts/chart-data-set.ts
@@ -122,14 +122,20 @@ export const ChartDataSetModel = types
       if (self.fixedMaxA1 !== undefined && self.dataPoints.length <= self.fixedMaxA1) {
         return self.fixedMaxA1;
       } else if (!self.visibleDataPoints || self.visibleDataPoints.length === 0) {
-        if (self.maxPoints) {
+        if (self.initialMaxA1){
+          return self.initialMaxA1;
+        } else if (self.maxPoints) {
           return self.maxPoints;
         } else {
           return defaultMax;
         }
       } else if (self.visibleDataPoints && self.visibleDataPoints.length > 0 &&
         self.maxPoints && self.visibleDataPoints.length < self.maxPoints) {
-        return self.maxPoints;
+          if (self.initialMaxA1){
+            return self.initialMaxA1;
+          } else {
+            return self.maxPoints;
+          }
       } else {
         return Math.max(...self.visibleDataPoints.map(p => p.a1));
       }

--- a/src/models/spaces/charts/chart-data-set.ts
+++ b/src/models/spaces/charts/chart-data-set.ts
@@ -73,12 +73,17 @@ export const ChartDataSetModel = types
     fixedMaxA1: types.maybe(types.number),
     fixedMinA2: types.maybe(types.number),
     fixedMaxA2: types.maybe(types.number),
+    // if x data points are not sequential 1,2,3..., and we are setting maxPoints, we need to have an
+    // initial maximum which is not simply the value of maxPoints, which is otherwise the default.
+    initialMaxA1: types.maybe(types.number),
     // expandOnly is used for y-axis scaling. When requesting min/max point values,
     // if this is set the a2 / y axis max returns the max of the full data set, not just the visiblePoints
     expandOnly: false,
     fixedLabelRotation: types.maybe(types.number),
     dataStartIdx: types.maybe(types.number),
-    stack: types.maybe(types.string)
+    stack: types.maybe(types.string),
+    axisLabelA1: types.maybe(types.string),
+    axisLabelA2: types.maybe(types.string)
   })
   .views(self => ({
     get visibleDataPoints() {

--- a/src/models/spaces/charts/chart-data.ts
+++ b/src/models/spaces/charts/chart-data.ts
@@ -58,6 +58,14 @@ export const ChartDataModel = types
 
     get subsetIdx() {
       return self.dataSets[0].dataStartIdx;
+    },
+
+    get axisLabelA1() {
+      return self.dataSets[0].axisLabelA1;
+    },
+
+    get axisLabelA2() {
+      return self.dataSets[0].axisLabelA2;
     }
   }))
   .extend(self => {

--- a/src/models/spaces/populations/mouse-model/hawks-mice-interactive.ts
+++ b/src/models/spaces/populations/mouse-model/hawks-mice-interactive.ts
@@ -134,6 +134,9 @@ export function createInteractive(model: MousePopulationsModelType) {
     for (const prop of properties) {
       agent.set(prop[0], prop[1]);
     }
+
+    agent.set("age", Math.round(Math.random() * 10));
+
     env.addAgent(agent);
   }
 

--- a/src/models/spaces/populations/mouse-model/mice.ts
+++ b/src/models/spaces/populations/mouse-model/mice.ts
@@ -104,7 +104,7 @@ export function getMouseSpecies(model: MousePopulationsModelType) {
       }
       this.set("direction", newDir);
 
-      this.set("age", Math.round(Math.random() * 10));
+      this.set("age", 1);
 
       if (this.organism) {
         if (model["inheritance.breedWithInheritance"]) {
@@ -193,6 +193,7 @@ export function getMouseSpecies(model: MousePopulationsModelType) {
     agentClass: Mouse,
     geneticSpecies: MouseGeneticSpec,
     defs: {
+      MAX_AGE: 3000,
       MAX_HEALTH: 1,
       MATURITY_AGE: 9,
       CHANCE_OF_MUTATION: 0,

--- a/src/models/spaces/populations/mouse-model/mouse-populations-model.ts
+++ b/src/models/spaces/populations/mouse-model/mouse-populations-model.ts
@@ -5,7 +5,7 @@ import { ToolbarButton } from "../populations";
 import { ChartDataModel } from "../../charts/chart-data";
 
 const chartData = {
-  name: "Samples",
+  name: "Fur Color vs Time",
   dataSets: [
     {
       name: "White mice",

--- a/src/models/spaces/populations/mouse-model/mouse-populations-model.ts
+++ b/src/models/spaces/populations/mouse-model/mouse-populations-model.ts
@@ -12,6 +12,7 @@ const chartData = {
       dataPoints: [],
       color: "#f4ce83",
       maxPoints: 20,
+      initialMaxA1: 100,
       fixedMinA2: 0,
       fixedMaxA2: 50,
       expandOnly: true,
@@ -24,6 +25,7 @@ const chartData = {
       dataPoints: [],
       color: "#db9e26",
       maxPoints: 20,
+      initialMaxA1: 100,
       fixedMinA2: 0,
       fixedMaxA2: 50,
       expandOnly: true,
@@ -36,6 +38,7 @@ const chartData = {
       dataPoints: [],
       color: "#795423",
       maxPoints: 20,
+      initialMaxA1: 100,
       fixedMinA2: 0,
       fixedMaxA2: 50,
       expandOnly: true,
@@ -95,8 +98,9 @@ export const MousePopulationsModel = types
     Events.addEventListener(Environment.EVENTS.STEP, () => {
       if (interactive) {
         const date = interactive.environment.date;
+        // add data every 5th step
         if (date % 5 === 0) {
-          addData(date / 5, interactive.getData());
+          addData(date, interactive.getData());
         }
       }
     });

--- a/src/models/spaces/populations/mouse-model/mouse-populations-model.ts
+++ b/src/models/spaces/populations/mouse-model/mouse-populations-model.ts
@@ -15,7 +15,9 @@ const chartData = {
       fixedMinA2: 0,
       fixedMaxA2: 50,
       expandOnly: true,
-      fixedLabelRotation: 0
+      fixedLabelRotation: 0,
+      axisLabelA1: "Weeks",
+      axisLabelA2: "Number of mice"
     },
     {
       name: "Tan mice",
@@ -25,7 +27,9 @@ const chartData = {
       fixedMinA2: 0,
       fixedMaxA2: 50,
       expandOnly: true,
-      fixedLabelRotation: 0
+      fixedLabelRotation: 0,
+      axisLabelA1: "Weeks",
+      axisLabelA2: "Number of mice"
     },
     {
       name: "Brown mice",
@@ -35,7 +39,9 @@ const chartData = {
       fixedMinA2: 0,
       fixedMaxA2: 50,
       expandOnly: true,
-      fixedLabelRotation: 0
+      fixedLabelRotation: 0,
+      axisLabelA1: "Weeks",
+      axisLabelA2: "Number of mice"
     }
   ]
  };


### PR DESCRIPTION
This adds labels to the chart axes, following the pattern in Dat Cross Dam, and also scales the x axes so that we are showing weeks, where each step is 10 weeks.

This required a small addition to the dataSet model to add an initial max A1 value.