### PR TITLE
Add chart annotations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3820,6 +3820,13 @@
         "color-name": "^1.0.0"
       }
     },
+    "chartjs-plugin-annotation": {
+      "version": "git+https://github.com/chartjs/chartjs-plugin-annotation.git#b22a69b6d8f633c01dbab08899b88bad6714e010",
+      "from": "git+https://github.com/chartjs/chartjs-plugin-annotation.git#b22a69b6",
+      "requires": {
+        "chart.js": "^2.4.0"
+      }
+    },
     "check-more-types": {
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz",

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
   },
   "dependencies": {
     "chart.js": "^2.7.3",
+    "chartjs-plugin-annotation": "git+https://github.com/chartjs/chartjs-plugin-annotation.git#b22a69b6",
     "flat": "^4.1.0",
     "iframe-phone": "^1.2.0",
     "immutable": "^3.8.2",

--- a/src/components/charts/line-chart.tsx
+++ b/src/components/charts/line-chart.tsx
@@ -23,6 +23,7 @@ const defaultOptions: ChartOptions = {
   plugins: {
     annotation: {
       drawTime: "beforeDatasetsDraw",
+      events: ["click", "mouseenter", "mouseleave"],
       annotations: []
     }
   },

--- a/src/components/charts/line-chart.tsx
+++ b/src/components/charts/line-chart.tsx
@@ -4,6 +4,7 @@ import { observer } from "mobx-react";
 import { merge } from "lodash";
 import { ChartDataModelType } from "../../models/spaces/charts/chart-data";
 import { ChartOptions } from "chart.js";
+import "chartjs-plugin-annotation";
 import { ChartColors } from "../../models/spaces/charts/chart-data-set";
 import { hexToRGBValue } from "../../utilities/color-utils";
 import { LineChartControls } from "./line-chart-controls";
@@ -19,6 +20,12 @@ interface ILineProps {
 interface ILineState { }
 
 const defaultOptions: ChartOptions = {
+  plugins: {
+    annotation: {
+      drawTime: "beforeDatasetsDraw",
+      annotations: []
+    }
+  },
   animation: {
     duration: 0
   },
@@ -35,6 +42,7 @@ const defaultOptions: ChartOptions = {
   scales: {
     display: false,
     yAxes: [{
+      id: "y-axis-0",
       ticks: {
         min: 0,
         max: 100
@@ -45,6 +53,7 @@ const defaultOptions: ChartOptions = {
       }
     }],
     xAxes: [{
+      id: "x-axis-0",
       display: true,
       ticks: {
         min: 0,
@@ -159,7 +168,12 @@ export class LineChart extends BaseComponent<ILineProps, ILineState> {
             labelString: chartData.axisLabelA1
           }
         }]
-      }
+      },
+      plugins: {
+        annotation: {
+          annotations: chartData.formattedAnnotations
+        }
+      },
     });
     const w = width ? width : 400;
     const h = height ? height : 400;

--- a/src/components/spaces/populations/populations-container.tsx
+++ b/src/components/spaces/populations/populations-container.tsx
@@ -9,7 +9,8 @@ import { ToolbarButton } from "../../../models/spaces/populations/populations";
 import { AgentEnvironmentMouseEvent, Agent } from "populations.js";
 import { BackpackMouse } from "../../../models/backpack-mouse";
 
-import { EnvironmentColorType } from "../../../models/spaces/populations/mouse-model/mouse-populations-model";
+import { EnvironmentColorType,
+  EnvironmentColorNames } from "../../../models/spaces/populations/mouse-model/mouse-populations-model";
 
 interface SizeMeProps {
   size?: {
@@ -151,19 +152,8 @@ export class PopulationsComponent extends BaseComponent<IProps, IState> {
     }
   }
 
-  private renderChangeButtonText = (environmentColor?: EnvironmentColorType) => {
-    let colorReadable = "neutral";
-    switch (environmentColor) {
-      case "white":
-        colorReadable = "Beach";
-        break;
-      case "brown":
-        colorReadable = "Field";
-        break;
-      case "neutral":
-      default:
-        colorReadable = "Mixed";
-    }
+  private renderChangeButtonText = (environmentColor: EnvironmentColorType) => {
+    const colorReadable = EnvironmentColorNames[environmentColor];
     const colorClass = "environment-box " + colorReadable;
     return (
       <div className={colorClass}>{colorReadable}</div>

--- a/src/models/spaces/charts/chart-annotation.test.ts
+++ b/src/models/spaces/charts/chart-annotation.test.ts
@@ -22,7 +22,10 @@ describe("chart annotations", () => {
         content: "Test",
         enabled: true,
         position: "top",
-        xAdjust: 0
+        xAdjust: 0,
+        yAdjust: 0,
+        backgroundColor: "rgba(0,0,0,0.8)",
+        fontColor: "white"
       },
       borderColor: "red",
       borderDash: [10, 3],
@@ -35,7 +38,7 @@ describe("chart annotations", () => {
       type: "horizontalLine",
       value: 10,
       label: "Test",
-      labelOffset: 10,
+      labelXOffset: 10,
       color: "blue",
       thickness: 5
     });
@@ -49,7 +52,10 @@ describe("chart annotations", () => {
         content: "Test",
         enabled: true,
         position: "right",
-        yAdjust: 10
+        xAdjust: 10,
+        yAdjust: 0,
+        backgroundColor: "rgba(0,0,0,0.8)",
+        fontColor: "white"
       },
       borderColor: "blue",
       borderWidth: 5
@@ -95,8 +101,7 @@ describe("chart annotations", () => {
       scaleID: "x-axis-0",
       value: 20,
       label: {
-        position: "top",
-        xAdjust: 0
+        position: "top"
       },
       borderColor: "red",
       borderWidth: 2
@@ -119,8 +124,7 @@ describe("chart annotations", () => {
       scaleID: "y-axis-0",
       value: 0,
       label: {
-        position: "right",
-        yAdjust: 0
+        position: "right"
       },
       borderColor: "red",
       borderWidth: 2

--- a/src/models/spaces/charts/chart-annotation.test.ts
+++ b/src/models/spaces/charts/chart-annotation.test.ts
@@ -56,6 +56,30 @@ describe("chart annotations", () => {
     });
   });
 
+  it("can create a box annotation", () => {
+    annotation = ChartAnnotationModel.create({
+      type: "box",
+      xMin: 25,
+      xMax: 40,
+      yMax: 20,
+      yMin:  15,
+      color: "red"
+    });
+
+    expect(annotation.formatted).toEqual({
+      type: "box",
+      xScaleID: "x-axis-0",
+      yScaleID: "y-axis-0",
+      xMin: 25,
+      xMax: 40,
+      yMax: 20,
+      yMin:  15,
+      borderColor: "red",
+      borderWidth: 2,
+      backgroundColor: "red",
+    });
+  });
+
   it("can create a chart with annotations", () => {
     chart = ChartDataModel.create({
       name: "Samples",

--- a/src/models/spaces/charts/chart-annotation.test.ts
+++ b/src/models/spaces/charts/chart-annotation.test.ts
@@ -1,0 +1,127 @@
+import { ChartAnnotationModel, ChartAnnotationType } from "./chart-annotation";
+import { ChartDataModelType, ChartDataModel } from "./chart-data";
+
+describe("chart annotations", () => {
+  let annotation: ChartAnnotationType;
+  let chart: ChartDataModelType;
+
+  it("can create a vertical line annotation", () => {
+    annotation = ChartAnnotationModel.create({
+      type: "verticalLine",
+      value: 10,
+      label: "Test",
+      dashArray: [10, 3]
+    });
+
+    expect(annotation.formatted).toEqual({
+      type: "line",
+      mode: "vertical",
+      scaleID: "x-axis-0",
+      value: 10,
+      label: {
+        content: "Test",
+        enabled: true,
+        position: "top",
+        xAdjust: 0
+      },
+      borderColor: "red",
+      borderDash: [10, 3],
+      borderWidth: 2
+    });
+  });
+
+  it("can create a horizontal line annotation", () => {
+    annotation = ChartAnnotationModel.create({
+      type: "horizontalLine",
+      value: 10,
+      label: "Test",
+      labelOffset: 10,
+      color: "blue",
+      thickness: 5
+    });
+
+    expect(annotation.formatted).toEqual({
+      type: "line",
+      mode: "horizontal",
+      scaleID: "y-axis-0",
+      value: 10,
+      label: {
+        content: "Test",
+        enabled: true,
+        position: "right",
+        yAdjust: 10
+      },
+      borderColor: "blue",
+      borderWidth: 5
+    });
+  });
+
+  it("can create a chart with annotations", () => {
+    chart = ChartDataModel.create({
+      name: "Samples",
+      annotations: [{
+        type: "verticalLine",
+        value: 20
+      }]
+    });
+
+    expect(chart.formattedAnnotations).toEqual([{
+      type: "line",
+      mode: "vertical",
+      scaleID: "x-axis-0",
+      value: 20,
+      label: {
+        position: "top",
+        xAdjust: 0
+      },
+      borderColor: "red",
+      borderWidth: 2
+    }]);
+  });
+
+  it("can add annotations to charts", () => {
+    chart = ChartDataModel.create({
+      name: "Samples"
+    });
+
+    chart.addAnnotation(ChartAnnotationModel.create({
+      type: "horizontalLine",
+      value: 0
+    }));
+
+    expect(chart.formattedAnnotations).toEqual([{
+      type: "line",
+      mode: "horizontal",
+      scaleID: "y-axis-0",
+      value: 0,
+      label: {
+        position: "right",
+        yAdjust: 0
+      },
+      borderColor: "red",
+      borderWidth: 2
+    }]);
+  });
+
+  it("can clear annotations from charts", () => {
+    chart = ChartDataModel.create({
+      name: "Samples"
+    });
+
+    chart.addAnnotation(ChartAnnotationModel.create({
+      type: "horizontalLine",
+      value: 0
+    }));
+    chart.addAnnotation(ChartAnnotationModel.create({
+      type: "horizontalLine",
+      value: 1
+    }));
+
+    expect(chart.formattedAnnotations.length).toBe(2);
+
+    chart.clearAnnotations();
+
+    expect(chart.formattedAnnotations.length).toBe(0);
+  });
+
+});

--- a/src/models/spaces/charts/chart-annotation.ts
+++ b/src/models/spaces/charts/chart-annotation.ts
@@ -78,6 +78,18 @@ export const ChartAnnotationModel = types
 
       return formatted;
     }
+  }))
+  .actions(self => ({
+    setValue: (value: number) => {
+      self.value = value;
+    },
+
+    setBounds: (bounds: {xMin?: number, xMax?: number, yMin?: number, yMax?: number}) => {
+      if (bounds.xMin) self.xMin = bounds.xMin;
+      if (bounds.xMax) self.xMax = bounds.xMax;
+      if (bounds.yMin) self.yMin = bounds.yMin;
+      if (bounds.yMax) self.yMax = bounds.yMax;
+    }
   }));
 
 export type ChartAnnotationType = Instance<typeof ChartAnnotationModel>;

--- a/src/models/spaces/charts/chart-annotation.ts
+++ b/src/models/spaces/charts/chart-annotation.ts
@@ -18,6 +18,8 @@ export const ChartAnnotationModel = types
     thickness: types.optional(types.number, 2),
     dashArray: types.array(types.number),
     label: types.maybe(types.string),
+    labelColor: types.optional(types.string, "white"),
+    labelBackgroundColor: types.optional(types.string, "rgba(0,0,0,0.8)"),
     labelOffset: types.optional(types.number, 0),
     xMin: types.maybe(types.number),
     xMax: types.maybe(types.number),
@@ -39,7 +41,9 @@ export const ChartAnnotationModel = types
           value: self.value,
           label: {
             position: "right",
-            yAdjust: self.labelOffset
+            yAdjust: self.labelOffset,
+            fontColor: self.labelColor,
+            backgroundColor: self.labelBackgroundColor
           },
           ...formatted
         };
@@ -51,7 +55,9 @@ export const ChartAnnotationModel = types
           value: self.value,
           label: {
             position: "top",
-            xAdjust: self.labelOffset
+            xAdjust: self.labelOffset,
+            fontColor: self.labelColor,
+            backgroundColor: self.labelBackgroundColor
           },
           ...formatted
         };

--- a/src/models/spaces/charts/chart-annotation.ts
+++ b/src/models/spaces/charts/chart-annotation.ts
@@ -1,0 +1,72 @@
+import { types, Instance } from "mobx-state-tree";
+
+/**
+ * This model tries to reduce the number of options that need to be specified when defining an
+ * annotation, by making lots of decisions in `formatted`. See tests.
+ *
+ * If we end up needing to add every little option, then we should make the model just look identical
+ * to the annotation def.
+ *
+ * See https://github.com/chartjs/chartjs-plugin-annotation
+ */
+
+export const ChartAnnotationModel = types
+  .model("ChartAnnotation", {
+    type: types.string,   // "horizontalLine", "verticalLine", "box"
+    value: types.maybe(types.number),
+    color: types.optional(types.string, "red"),
+    thickness: types.optional(types.number, 2),
+    dashArray: types.array(types.number),
+    label: types.maybe(types.string),
+    labelOffset: types.optional(types.number, 0),
+    xMin: types.maybe(types.number),
+    xMax: types.maybe(types.number),
+    yMax: types.maybe(types.number),
+    yMin: types.maybe(types.number)
+  })
+  .views(self => ({
+    get formatted() {
+      let formatted: any = {
+        value: self.value,
+        borderColor: self.color,
+        borderWidth: self.thickness
+      };
+
+      if (self.type === "horizontalLine") {
+        formatted = {
+          type: "line",
+          mode: "horizontal",
+          scaleID: "y-axis-0",
+          label: {
+            position: "right",
+            yAdjust: self.labelOffset
+          },
+          ...formatted
+        };
+      } else if (self.type === "verticalLine") {
+        formatted = {
+          type: "line",
+          mode: "vertical",
+          scaleID: "x-axis-0",
+          label: {
+            position: "top",
+            xAdjust: self.labelOffset
+          },
+          ...formatted
+        };
+      }
+
+      if (self.label) {
+        formatted.label.enabled = true;
+        formatted.label.content = self.label;
+      }
+
+      if (self.dashArray.length) {
+        formatted.borderDash = self.dashArray;
+      }
+
+      return formatted;
+    }
+  }));
+
+export type ChartAnnotationType = Instance<typeof ChartAnnotationModel>;

--- a/src/models/spaces/charts/chart-annotation.ts
+++ b/src/models/spaces/charts/chart-annotation.ts
@@ -27,7 +27,6 @@ export const ChartAnnotationModel = types
   .views(self => ({
     get formatted() {
       let formatted: any = {
-        value: self.value,
         borderColor: self.color,
         borderWidth: self.thickness
       };
@@ -37,6 +36,7 @@ export const ChartAnnotationModel = types
           type: "line",
           mode: "horizontal",
           scaleID: "y-axis-0",
+          value: self.value,
           label: {
             position: "right",
             yAdjust: self.labelOffset
@@ -48,10 +48,21 @@ export const ChartAnnotationModel = types
           type: "line",
           mode: "vertical",
           scaleID: "x-axis-0",
+          value: self.value,
           label: {
             position: "top",
             xAdjust: self.labelOffset
           },
+          ...formatted
+        };
+      } else if (self.type === "box") {
+        const { xMin, xMax, yMin, yMax } = self;
+        formatted = {
+          type: "box",
+          xScaleID: "x-axis-0",
+          yScaleID: "y-axis-0",
+          backgroundColor: self.color,
+          xMin, xMax, yMin, yMax,
           ...formatted
         };
       }

--- a/src/models/spaces/charts/chart-data.ts
+++ b/src/models/spaces/charts/chart-data.ts
@@ -108,6 +108,10 @@ export const ChartDataModel = types
       self.annotations.push(annotation);
     }
 
+    function removeAnnotation(annotation: ChartAnnotationType) {
+      self.annotations.remove(annotation);
+    }
+
     function clearAnnotations() {
       self.annotations.clear();
     }
@@ -118,6 +122,7 @@ export const ChartDataModel = types
         addDataSet,
         setDataSetSubset,
         addAnnotation,
+        removeAnnotation,
         clearAnnotations
       }
     };

--- a/src/models/spaces/charts/chart-data.ts
+++ b/src/models/spaces/charts/chart-data.ts
@@ -1,11 +1,13 @@
 import { types, Instance } from "mobx-state-tree";
 import { ChartDataSetModel, ChartDataSetModelType, ChartColors } from "./chart-data-set";
+import { ChartAnnotationModel, ChartAnnotationType } from "./chart-annotation";
 
 export const ChartDataModel = types
   .model("ChartData", {
     name: types.string,
     dataSets: types.array(ChartDataSetModel),
-    labels: types.array(types.string)
+    labels: types.array(types.string),
+    annotations: types.array(ChartAnnotationModel)
   })
   .views(self => ({
     get visibleDataSets() {
@@ -71,6 +73,10 @@ export const ChartDataModel = types
 
     get axisLabelA2() {
       return self.visibleDataSets[0].axisLabelA2;
+    },
+
+    get formattedAnnotations() {
+      return self.annotations.map(a => a.formatted);
     }
   }))
   .extend(self => {
@@ -98,11 +104,21 @@ export const ChartDataModel = types
       });
     }
 
+    function addAnnotation(annotation: ChartAnnotationType) {
+      self.annotations.push(annotation);
+    }
+
+    function clearAnnotations() {
+      self.annotations.clear();
+    }
+
     return {
       actions: {
         allData,
         addDataSet,
-        setDataSetSubset
+        setDataSetSubset,
+        addAnnotation,
+        clearAnnotations
       }
     };
   });

--- a/src/models/spaces/populations/mouse-model/hawks-mice-interactive.ts
+++ b/src/models/spaces/populations/mouse-model/hawks-mice-interactive.ts
@@ -112,10 +112,13 @@ export function createInteractive(model: MousePopulationsModelType) {
       const tanCap = whiteCap + Math.round((num / 100) * model["initialPopulation.tan"]);
       if (i < whiteCap) {
         colorTrait = createColorTraitByPhenotype("white");
+        numWhite++;
       } else if (i < tanCap) {
         colorTrait = createColorTraitByPhenotype("tan");
+        numTan++;
       } else {
         colorTrait = createColorTraitByPhenotype("brown");
+        numBrown++;
       }
 
       addAgent(mouseSpecies, [], [

--- a/src/models/spaces/populations/mouse-model/mouse-populations-model.ts
+++ b/src/models/spaces/populations/mouse-model/mouse-populations-model.ts
@@ -211,6 +211,15 @@ export const MousePopulationsModel = types
       });
     }
 
+    Events.addEventListener(Environment.EVENTS.START, () => {
+      if (interactive) {
+        const date = interactive.environment.date;
+        if (date === 0) {
+          addData(date, interactive.getData());
+        }
+      }
+    });
+
     Events.addEventListener(Environment.EVENTS.STEP, () => {
       if (interactive) {
         const date = interactive.environment.date;

--- a/src/models/spaces/populations/mouse-model/mouse-populations-model.ts
+++ b/src/models/spaces/populations/mouse-model/mouse-populations-model.ts
@@ -4,7 +4,22 @@ import { Interactive, Events, Environment, Agent } from "populations.js";
 import { ToolbarButton } from "../populations";
 import { ChartDataModel } from "../../charts/chart-data";
 import { hawkSpecies } from "./hawks";
-import { ChartAnnotationModel } from "../../charts/chart-annotation";
+import { ChartAnnotationModel, ChartAnnotationType } from "../../charts/chart-annotation";
+
+const dataColors = {
+  white: {
+    mice: "#f4ce83",
+    environment: "rgba(251,235,205, 0.5)"
+  },
+  neutral: {
+    mice: "#db9e26",
+    environment: "rgba(241,216,168, 0.5)"
+  },
+  brown: {
+    mice: "#795423",
+    environment: "rgba(201,187,167, 0.5)"
+  }
+};
 
 const chartNames = {
   color: "Fur Color vs Time",
@@ -18,7 +33,7 @@ const chartData = {
     {
       name: "White mice",
       dataPoints: [],
-      color: "#f4ce83",
+      color: dataColors.white.mice,
       maxPoints: 20,
       initialMaxA1: 100,
       fixedMinA2: 0,
@@ -31,7 +46,7 @@ const chartData = {
     {
       name: "Tan mice",
       dataPoints: [],
-      color: "#db9e26",
+      color: dataColors.neutral.mice,
       maxPoints: 20,
       initialMaxA1: 100,
       fixedMinA2: 0,
@@ -44,7 +59,7 @@ const chartData = {
     {
       name: "Brown mice",
       dataPoints: [],
-      color: "#795423",
+      color: dataColors.brown.mice,
       maxPoints: 20,
       initialMaxA1: 100,
       fixedMinA2: 0,
@@ -222,11 +237,24 @@ export const MousePopulationsModel = types
       }
     });
 
-    function clearGraph() {
+    let lastBoxAnnotation: ChartAnnotationType;
+
+    function setupGraph() {
       self.chartData.dataSets.forEach(d => d.clearDataPoints());
       self.chartData.clearAnnotations();
       hawksAdded = false;
+      lastBoxAnnotation = ChartAnnotationModel.create({
+        type: "box",
+        color: dataColors[self.environment].environment,
+        xMin: 0,
+        xMax: Infinity,
+        yMin: 0,
+        yMax: Infinity
+      });
+      self.chartData.addAnnotation(lastBoxAnnotation);
     }
+
+    setupGraph();
 
     return {
       views: {
@@ -249,6 +277,19 @@ export const MousePopulationsModel = types
       actions: {
         setEnvironmentColor(color: EnvironmentColorType) {
           self.environment = color;
+          if (interactive) {
+            const date = interactive.environment.date;
+            lastBoxAnnotation.setBounds({xMax: date});
+            lastBoxAnnotation = ChartAnnotationModel.create({
+              type: "box",
+              color: dataColors[color].environment,
+              xMin: date,
+              xMax: Infinity,
+              yMin: 0,
+              yMax: Infinity
+            });
+            self.chartData.addAnnotation(lastBoxAnnotation);
+          }
         },
         setBreedWithMutations(value: boolean) {
           self["inheritance.breedWithMutations"] = value;
@@ -260,7 +301,7 @@ export const MousePopulationsModel = types
           if (interactive) {
             interactive.reset();
           }
-          clearGraph();
+          setupGraph();
         },
         toggleShowMaxPoints() {
           self.showMaxPoints = !self.showMaxPoints;
@@ -295,7 +336,7 @@ export const MousePopulationsModel = types
         },
         destroyInteractive() {
           interactive = undefined;
-          clearGraph();
+          setupGraph();
         }
       }
     };

--- a/src/models/spaces/populations/mouse-model/mouse-populations-model.ts
+++ b/src/models/spaces/populations/mouse-model/mouse-populations-model.ts
@@ -9,15 +9,15 @@ import { ChartAnnotationModel, ChartAnnotationType } from "../../charts/chart-an
 const dataColors = {
   white: {
     mice: "#f4ce83",
-    environment: "rgba(251,235,205, 0.5)"
+    environment: "rgb(251,235,205)"
   },
   neutral: {
     mice: "#db9e26",
-    environment: "rgba(241,216,168, 0.5)"
+    environment: "rgb(241,216,168)"
   },
   brown: {
     mice: "#795423",
-    environment: "rgba(201,187,167, 0.5)"
+    environment: "rgb(201,187,167)"
   }
 };
 
@@ -237,21 +237,19 @@ export const MousePopulationsModel = types
       }
     });
 
-    let lastBoxAnnotation: ChartAnnotationType;
-
     function setupGraph() {
       self.chartData.dataSets.forEach(d => d.clearDataPoints());
       self.chartData.clearAnnotations();
       hawksAdded = false;
-      lastBoxAnnotation = ChartAnnotationModel.create({
-        type: "box",
-        color: dataColors[self.environment].environment,
-        xMin: 0,
-        xMax: Infinity,
-        yMin: 0,
-        yMax: Infinity
-      });
-      self.chartData.addAnnotation(lastBoxAnnotation);
+      self.chartData.addAnnotation(ChartAnnotationModel.create({
+        type: "verticalLine",
+        value: 0,
+        color: "black",
+        label: self.environment,
+        labelOffset: -30,
+        labelColor: "black",
+        labelBackgroundColor: dataColors[self.environment].environment
+      }));
     }
 
     setupGraph();
@@ -279,16 +277,15 @@ export const MousePopulationsModel = types
           self.environment = color;
           if (interactive) {
             const date = interactive.environment.date;
-            lastBoxAnnotation.setBounds({xMax: date});
-            lastBoxAnnotation = ChartAnnotationModel.create({
-              type: "box",
-              color: dataColors[color].environment,
-              xMin: date,
-              xMax: Infinity,
-              yMin: 0,
-              yMax: Infinity
-            });
-            self.chartData.addAnnotation(lastBoxAnnotation);
+            self.chartData.addAnnotation(ChartAnnotationModel.create({
+              type: "verticalLine",
+              value: date,
+              color: "black",
+              label: color,
+              labelOffset: -30,
+              labelColor: "black",
+              labelBackgroundColor: dataColors[color].environment
+            }));
           }
         },
         setBreedWithMutations(value: boolean) {

--- a/src/models/spaces/populations/mouse-model/mouse-populations-model.ts
+++ b/src/models/spaces/populations/mouse-model/mouse-populations-model.ts
@@ -1,8 +1,10 @@
 import { types, Instance } from "mobx-state-tree";
 import { createInteractive, HawksMiceInteractive } from "./hawks-mice-interactive";
-import { Interactive, Events, Environment } from "populations.js";
+import { Interactive, Events, Environment, Agent } from "populations.js";
 import { ToolbarButton } from "../populations";
 import { ChartDataModel } from "../../charts/chart-data";
+import { hawkSpecies } from "./hawks";
+import { ChartAnnotationModel } from "../../charts/chart-annotation";
 
 const chartNames = {
   color: "Fur Color vs Time",
@@ -204,8 +206,26 @@ export const MousePopulationsModel = types
       }
     });
 
+    let hawksAdded = false;
+    Events.addEventListener(Environment.EVENTS.AGENT_ADDED, (evt: any) => {
+      if (interactive) {
+        if (!hawksAdded && evt.detail && evt.detail.agent.species.speciesName === "hawks") {
+          self.chartData.addAnnotation(ChartAnnotationModel.create({
+            type: "verticalLine",
+            value: interactive.environment.date,
+            dashArray: [10, 3],
+            label: "Hawks added",
+            labelOffset: -50
+          }));
+          hawksAdded = true;
+        }
+      }
+    });
+
     function clearGraph() {
       self.chartData.dataSets.forEach(d => d.clearDataPoints());
+      self.chartData.clearAnnotations();
+      hawksAdded = false;
     }
 
     return {


### PR DESCRIPTION
This adds a chart annotation plugin, and adds annotations for the population model.

This adds an annotation model object that tries to simplify the options for how the annotations will look, while still providing a fair bit of customization.

Box annotations were added to the model, and are tested, but in the end were not used for the populations model. The box annotations can be seen at this branch: https://connected-bio-spaces.concord.org/branch/add-chart-annotations/ (Try running the model and switching environments).