### PR TITLE
Click to add mice to the organism panel

### DIFF
--- a/src/components/collect-button.tsx
+++ b/src/components/collect-button.tsx
@@ -47,7 +47,7 @@ export class CollectButtonComponent extends BaseComponent<IProps, IState> {
           </svg>
         </div>
         <div className="collect-button-outline">
-          <div className={buttonClass} onClick={handleMouse} data-test="stored-mouse-class">
+          <div className={buttonClass} onMouseDown={handleMouse} data-test="stored-mouse-class">
             <div className={innerOutlineClass} data-test="inner-outline">
               <img src={mouse.baseImage} className="icon" data-test="stored-mouse-image"/>
               <div className="label" data-test="stored-mouse-label">{mouse.label}</div>

--- a/src/components/spaces/organisms-space.tsx
+++ b/src/components/spaces/organisms-space.tsx
@@ -133,8 +133,6 @@ export class OrganismsSpaceComponent extends BaseComponent<IProps, IState> {
       <div className="fullwidth">
         <CollectButtonComponent
           backpackMouse={organismsMouse && organismsMouse.backpackMouse}
-          clickMouse={this.clickMouse}
-          clickEmpty={this.clickEmpty(rowIndex)}
           clickClose={this.clickClose(rowIndex)}
           placeable={activeMouse != null}
         />
@@ -157,19 +155,6 @@ export class OrganismsSpaceComponent extends BaseComponent<IProps, IState> {
   private setRightPanel = (rowIndex: number) => (panelType: RightPanelType) => {
     const { organisms } = this.stores;
     organisms.rows[rowIndex].setRightPanel(panelType);
-  }
-
-  private clickMouse = () => {
-    // Clicks only work on empty slots
-  }
-
-  private clickEmpty = (rowIndex: number) => () => {
-    const { backpack, organisms } = this.stores;
-    const { activeMouse } = backpack;
-    if (activeMouse != null) {
-      organisms.setRowBackpackMouse(rowIndex, activeMouse);
-      backpack.deselectMouse();
-    }
   }
 
   private clickClose = (rowIndex: number) => () => {

--- a/src/models/spaces/organisms/organisms-space.ts
+++ b/src/models/spaces/organisms/organisms-space.ts
@@ -159,6 +159,15 @@ export const OrganismsSpaceModel = types
   }))
   .views(self => {
     return {
+      get firstEmptyRow() {
+        if (!self.rows[0].organismsMouse) {
+          return 0;
+        }
+        if (!self.rows[1].organismsMouse) {
+          return 1;
+        }
+        return null;
+      },
       getOrganelleLabel(organelle: OrganelleType) {
         if (self.useMysteryOrganelles) {
           return kOrganelleInfo[organelle].mysteryLabel;
@@ -216,6 +225,14 @@ export const OrganismsSpaceModel = types
         self.showProteinInfoBox = !self.showProteinInfoBox;
       }
     };
-  });
+  })
+  .actions(self => ({
+    activeBackpackMouseUpdated(backpackMouse: BackpackMouseType) {
+      if (self.firstEmptyRow !== null) {
+        self.setRowBackpackMouse(self.firstEmptyRow, backpackMouse);
+        return true;
+      }
+    }
+  }));
 
 export type OrganismsSpaceModelType = Instance<typeof OrganismsSpaceModel>;

--- a/src/models/stores.ts
+++ b/src/models/stores.ts
@@ -8,6 +8,7 @@ import { ConnectedBioAuthoring } from "../authoring";
 import { QueryParams } from "../utilities/url-params";
 import { OrganismsMouseModelType } from "./spaces/organisms/organisms-mouse";
 import { OrganismsRowModelType } from "./spaces/organisms/organisms-row";
+import { autorun } from "mobx";
 
 export type Curriculum = "mouse";
 
@@ -30,6 +31,16 @@ export function createStores(initialModel: ConnectedBioModelCreationType): IStor
   // since organisms may contain references to backpack mice, yet is in a different tree, we need to pass them in
   // explicitly so they can be found
   const organisms = createOrganismsModel(initialModel.organisms, backpack);
+
+  // inform organisms space if user selects a backpack mouse
+  autorun(() => {
+    if (ui.investigationPanelSpace === "organism" && backpack.activeMouse) {
+      const organismAdded = organisms.activeBackpackMouseUpdated(backpack.activeMouse);
+      if (organismAdded) {
+        backpack.deselectMouse();
+      }
+    }
+  });
 
   return {
     ui,

--- a/src/models/stores.ts
+++ b/src/models/stores.ts
@@ -9,6 +9,7 @@ import { QueryParams } from "../utilities/url-params";
 import { OrganismsMouseModelType } from "./spaces/organisms/organisms-mouse";
 import { OrganismsRowModelType } from "./spaces/organisms/organisms-row";
 import { autorun } from "mobx";
+import { onAction } from "mobx-state-tree";
 
 export type Curriculum = "mouse";
 
@@ -39,6 +40,21 @@ export function createStores(initialModel: ConnectedBioModelCreationType): IStor
       if (organismAdded) {
         backpack.deselectMouse();
       }
+    }
+  });
+
+  // Prevent user from having to deselect and reselect a selected backpack mouse in order to
+  // add to a row.
+  // deselect mice on space changes
+  onAction(ui, call => {
+    if (call.name === "setInvestigationPanelSpace") {
+      backpack.deselectMouse();
+    }
+  });
+  // and when organism rows are cleared
+  onAction(organisms, call => {
+    if (call.name === "clearRowBackpackMouse") {
+      backpack.deselectMouse();
     }
   });
 


### PR DESCRIPTION
This updates the UX from requiring the user to click twice (once on the backpack and once in the row) to single click on the backpack, which auto-populates the first available row, if any.

This also deselects mice on space changes, and on row clearing, to prevent the user from needing to click to deselect a mouse before they can add it.

There is currently no purpose now to a backpack mouse being in a selected state. We can discuss at the meeting whether we should remove this behavior entirely, or if it will come up in a later interaction.