### PR TITLE
Load authoring data into form

### DIFF
--- a/src/components/authoring.tsx
+++ b/src/components/authoring.tsx
@@ -7,8 +7,11 @@ import { QueryParams } from "../utilities/url-params";
 import { JSONSchema6 } from "json-schema";
 import * as authoringSchema from "../authoring-schema.json";
 import { ConnectedBioAuthoring } from "../authoring";
+import { ConnectedBioModelCreationType } from "../models/stores";
 
-interface IProps extends IBaseProps {}
+interface IProps extends IBaseProps {
+  initialAuthoring: ConnectedBioModelCreationType;
+}
 interface IState {}
 
 export const defaultAuthoring: ConnectedBioAuthoring = {
@@ -106,14 +109,16 @@ const uiSchema = {
 export class AuthoringComponent extends BaseComponent<IProps, IState> {
   public render() {
     const onSubmit = (e: ISubmitEvent<QueryParams>) => {
-      const encodedParams = encodeURIComponent(JSON.stringify(e.formData));
+      const authoredForm = e.formData;
+      delete authoredForm.authoring;
+      const encodedParams = encodeURIComponent(JSON.stringify(authoredForm));
       window.open(`${location.origin}${location.pathname}?${encodedParams}`, "connected-bio-spaces");
     };
     return (
       <div className="authoring">
         <Form
           schema={authoringSchema as JSONSchema6}
-          formData={defaultAuthoring}
+          formData={this.props.initialAuthoring}
           uiSchema={uiSchema}
           onSubmit={onSubmit} />
       </div>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -22,25 +22,25 @@ function initializeModel(studentData: UserSaveDataType) {
 
   const initialStore: ConnectedBioModelCreationType = merge({}, defaultAuthoring, urlParams, studentData);
 
-  const stores = createStores( initialStore );
-
-  // Save data everytime stores change
-  function saveUserData() {
-    phone.post("interactiveState", getUserSnapshot(stores));
-  }
-  onSnapshot(stores.backpack, saveUserData);
-  onSnapshot(stores.ui, saveUserData);
-  onSnapshot(stores.organisms, saveUserData);
-
   const appRoot = document.getElementById("app");
 
   if (urlParams.authoring) {
     appRoot!.classList.add("authoring");
     ReactDOM.render((
-      <AuthoringComponent />
+      <AuthoringComponent initialAuthoring={initialStore} />
       ), appRoot
     );
   } else {
+    const stores = createStores( initialStore );
+
+    // Save data everytime stores change
+    const saveUserData = () => {
+      phone.post("interactiveState", getUserSnapshot(stores));
+    };
+    onSnapshot(stores.backpack, saveUserData);
+    onSnapshot(stores.ui, saveUserData);
+    onSnapshot(stores.organisms, saveUserData);
+
     ReactDOM.render(
       <Provider stores={stores}>
         <AppComponent showTopBar={initialStore.topBar} />

--- a/src/utilities/url-params.ts
+++ b/src/utilities/url-params.ts
@@ -7,13 +7,15 @@ export interface QueryParams extends ConnectedBioAuthoring {
 let params: QueryParams;
 
 try {
-  const queryString = location.search.length > 1 ? decodeURIComponent(location.search.substring(1)) : "{}";
+  const queryString = location.search.length > 1
+    ? decodeURIComponent(location.search.substring(1).replace("authoring", ""))
+    : "{}";
   params = JSON.parse(queryString);
 } catch (e) {
   params = {};
 }
 
-if (location.search === "?authoring") {
+if (location.search.indexOf("authoring") > -1) {
   params.authoring = true;
 }
 

--- a/src/utilities/url-params.ts
+++ b/src/utilities/url-params.ts
@@ -15,7 +15,7 @@ try {
   params = {};
 }
 
-if (location.search.indexOf("authoring") > -1) {
+if (location.search.indexOf("authoring") === 1) {
   params.authoring = true;
 }
 


### PR DESCRIPTION
This is a fairly simple change which takes the authored data from the url, plus the authoring defaults, and passes them to the authoring form to be used as the initial form state.

It also now allows `?authoring` to be in a url with the other parameters, instead of requiring it to be the only url param, to allow it to be added to existing authoring urls. This allows us to take the authored url

http://localhost:8080/?%7B"curriculum"%3A"mouse"....

and get the authoring page version simply by inserting "authoring" after
the ?

http://localhost:8080/?authoring%7B"curriculum"%3A"mouse"

This is a little weird, because unescaped it looks like `?authoring{"curriculum": "mouse", ...}` but it seemed the best way both to be backwards-compatible with just using `?authoring` by itself, and also making it simple to see the authoring page of a model.