### PR TITLE
Udate Remove Hawks button state when user resets simulation

### DIFF
--- a/src/models/spaces/populations/mouse-model/mouse-populations-model.ts
+++ b/src/models/spaces/populations/mouse-model/mouse-populations-model.ts
@@ -345,6 +345,7 @@ export const MousePopulationsModel = types
           if (interactive) {
             interactive.reset();
           }
+          this.setHawksAdded(false);
           setupGraph();
         },
         toggleShowMaxPoints() {


### PR DESCRIPTION
We were not updating the state when the user reset the pop sim and the "add hawks" button would display as "remove hawks" to the user.

[#164438603]