### PR TITLE
Use integer values on Pop Graph to avoid graph resizing

### DIFF
--- a/src/components/charts/line-chart.tsx
+++ b/src/components/charts/line-chart.tsx
@@ -162,7 +162,10 @@ export class LineChart extends BaseComponent<ILineProps, ILineState> {
             min: minMaxValues.minA1,
             max: minMaxValues.maxA1,
             minRotation: chartData.dataLabelRotation,
-            maxRotation: chartData.dataLabelRotation
+            maxRotation: chartData.dataLabelRotation,
+            userCallback: (label: any) => {
+              return Math.ceil(label);
+            },
           },
           scaleLabel: {
             display: !!chartData.axisLabelA1,


### PR DESCRIPTION
The population graph was resizing (wiggling) as it switched between x axis labels with different string lengths.  This was caused by some axis label values being integers and others having decimals (such as 180 and 180.5).  Changes round all axis label values on the line graph to eliminate the graph resizing and wiggle effect.