### PR TITLE
Removes MobX-specific features from chart type setting

### DIFF
--- a/src/models/spaces/populations/mouse-model/mouse-populations-model.ts
+++ b/src/models/spaces/populations/mouse-model/mouse-populations-model.ts
@@ -190,7 +190,8 @@ export const MousePopulationsModel = types
     "showMaxPoints": false,
     "enableColorChart": true,
     "enableGenotypeChart": true,
-    "enableAllelesChart": true
+    "enableAllelesChart": true,
+    "userChartType": types.union(types.undefined, ChartTypeEnum)
   })
   .volatile(self => ({
     hawksAdded: false
@@ -200,13 +201,15 @@ export const MousePopulationsModel = types
     let lastEnvironmentColorAnnotationDate = 0;
     let lastEnvironmentColorAnnotation: ChartAnnotationType;
 
-    const initialChart: ChartType = self.enableColorChart ? "color" :
+    function getChartTypeOrDefault() {
+      return self.userChartType ? self.userChartType :
+      self.enableColorChart ? "color" :
       self.enableGenotypeChart ? "genotype" :
       self.enableAllelesChart ? "alleles" : "color";
-    const chartType = observable.box(initialChart);
+    }
 
     function setupChartForChartType() {
-      const chartString = chartType.get();
+      const chartString = getChartTypeOrDefault();
       self.chartData.name = chartNames[chartString as ChartType];
 
       self.chartData.dataSets[0].display = chartString === "color";
@@ -317,7 +320,7 @@ export const MousePopulationsModel = types
         },
 
         get chartType(): ChartType {
-          return chartType.get();
+          return getChartTypeOrDefault();
         },
 
         get chanceOfMutation() {
@@ -366,7 +369,7 @@ export const MousePopulationsModel = types
           self.showHeteroStack = show;
         },
         setChartType(type: ChartType) {
-          chartType.set(type);
+          self.userChartType = type;
           setupChartForChartType();
         },
         setHawksAdded(val: boolean) {

--- a/src/models/spaces/populations/mouse-model/mouse-populations-model.ts
+++ b/src/models/spaces/populations/mouse-model/mouse-populations-model.ts
@@ -1,11 +1,9 @@
 import { types, Instance } from "mobx-state-tree";
 import { createInteractive, HawksMiceInteractive } from "./hawks-mice-interactive";
-import { Interactive, Events, Environment, Agent } from "populations.js";
+import { Events, Environment } from "populations.js";
 import { ToolbarButton } from "../populations";
 import { ChartDataModel } from "../../charts/chart-data";
-import { hawkSpecies } from "./hawks";
 import { ChartAnnotationModel, ChartAnnotationType } from "../../charts/chart-annotation";
-import { observable } from "mobx";
 
 const dataColors = {
   white: {
@@ -190,11 +188,11 @@ export const MousePopulationsModel = types
     "showMaxPoints": false,
     "enableColorChart": true,
     "enableGenotypeChart": true,
-    "enableAllelesChart": true,
-    "userChartType": types.union(types.undefined, ChartTypeEnum)
+    "enableAllelesChart": true
   })
   .volatile(self => ({
-    hawksAdded: false
+    hawksAdded: false,
+    userChartType: undefined as (ChartType | undefined)
   }))
   .extend(self => {
     let interactive: HawksMiceInteractive | undefined;


### PR DESCRIPTION
Following up on @kswenson's suggestion to remove MobX-specific features from `chartType` functionality. I agree that this is cleaner than setting up observers in volatile state.

http://connected-bio-spaces.concord.org/branch/mst-only-charts/