### PR TITLE
Add authoring of graph and gametes buttons

### DIFF
--- a/src/authoring-schema.json
+++ b/src/authoring-schema.json
@@ -255,6 +255,22 @@
         "instructions": {
           "title": "Instructions (as markdown)",
           "type": "string"
+        },
+        "enableInspectGametes": {
+          "title": "Enable inspect gametes button",
+          "type": "boolean"
+        },
+        "enableColorChart": {
+          "title": "Enable mouse fur color pie chart",
+          "type": "boolean"
+        },
+        "enableGenotypeChart": {
+          "title": "Enable mouse genotypes pie chart",
+          "type": "boolean"
+        },
+        "enableSexChart": {
+          "title": "Enable mouse sex pie chart",
+          "type": "boolean"
         }
       }
     }

--- a/src/authoring.d.ts
+++ b/src/authoring.d.ts
@@ -40,6 +40,10 @@ export type ShowMysterySubstanceLabels = boolean;
 export type AllowZoomingToReceptor = boolean;
 export type AllowZoomingToNucleus = boolean;
 export type InstructionsAsMarkdown2 = string;
+export type EnableInspectGametesButton = boolean;
+export type EnableMouseFurColorPieChart = boolean;
+export type EnableMouseGenotypesPieChart = boolean;
+export type EnableMouseSexPieChart = boolean;
 
 export interface ConnectedBioAuthoring {
   curriculum?: Unit;
@@ -115,5 +119,9 @@ export interface OrganismModel {
 }
 export interface BreedingModel {
   instructions?: InstructionsAsMarkdown2;
+  enableInspectGametes?: EnableInspectGametesButton;
+  enableColorChart?: EnableMouseFurColorPieChart;
+  enableGenotypeChart?: EnableMouseGenotypesPieChart;
+  enableSexChart?: EnableMouseSexPieChart;
   [k: string]: any;
 }

--- a/src/components/authoring.tsx
+++ b/src/components/authoring.tsx
@@ -65,7 +65,10 @@ export const defaultAuthoring: ConnectedBioAuthoring = {
   },
   breeding: {
     instructions: "",
-    nestPairs: []
+    nestPairs: [],
+    enableColorChart: true,
+    enableGenotypeChart: true,
+    enableSexChart: true
   }
 };
 

--- a/src/components/authoring.tsx
+++ b/src/components/authoring.tsx
@@ -65,7 +65,6 @@ export const defaultAuthoring: ConnectedBioAuthoring = {
   },
   breeding: {
     instructions: "",
-    nestPairs: [],
     enableColorChart: true,
     enableGenotypeChart: true,
     enableSexChart: true

--- a/src/models/spaces/breeding/breeding.ts
+++ b/src/models/spaces/breeding/breeding.ts
@@ -99,9 +99,13 @@ export const BreedingModel = types
     nestPairs: types.array(NestPair),
     inspectedNestPairId: types.maybe(types.string),
     breedingNestPairId: types.maybe(types.string),
-    userChartType: types.optional(BreedingChartTypeEnum, "color"),
+    userChartType: types.maybe(BreedingChartTypeEnum),
     minLitterSize: 3,
-    maxLitterSize: 5
+    maxLitterSize: 5,
+    enableColorChart: true,
+    enableGenotypeChart: true,
+    enableSexChart: true,
+    enableInspectGametes: true,
   })
   .actions(self => ({
 
@@ -172,11 +176,18 @@ export const BreedingModel = types
   }))
   .views((self) => {
     return {
+      get chartType(): BreedingChartType {
+        return self.userChartType ? self.userChartType :
+          self.enableColorChart ? "color" :
+          self.enableGenotypeChart ? "genotype" :
+          self.enableSexChart ? "sex" : "color";
+      },
+    };
+  })
+  .views((self) => {
+    return {
       get activeBreedingPair(): INestPair | undefined {
         return self.nestPairs.find(pair => pair.id === self.breedingNestPairId);
-      },
-      get chartType(): BreedingChartType {
-        return self.userChartType ? self.userChartType : "color";
       },
       get toolbarButtons(): ToolbarButton[] {
         const buttons = [];
@@ -207,27 +218,30 @@ export const BreedingModel = types
         const buttons = [];
         buttons.push({
           title: "Fur Colors",
-          value: self.userChartType === "color",
+          value: self.chartType === "color",
           action: (val: boolean) => {
             self.setChartType("color");
           },
           section: "data",
+          disabled: !self.enableColorChart,
         });
         buttons.push({
           title: "Genotypes",
-          value: self.userChartType === "genotype",
+          value: self.chartType === "genotype",
           action: (val: boolean) => {
             self.setChartType("genotype");
           },
           section: "data",
+          disabled: !self.enableGenotypeChart,
         });
         buttons.push({
           title: "Sex",
-          value: self.userChartType === "sex",
+          value: self.chartType === "sex",
           action: (val: boolean) => {
             self.setChartType("sex");
           },
           section: "data",
+          disabled: !self.enableSexChart,
         });
 
         return buttons;


### PR DESCRIPTION
Add ability for author to turn on or off the breeding level graph types and the breeding level inspect gametes button.  Note that, at present, enabling/disabling inspect gametes has no effect as this button is always disabled (this feature will be used once we implement inspecting gametes).