### PR TITLE
Turn off show gametes when user disables button via authoring tools

### DIFF
--- a/src/components/authoring.tsx
+++ b/src/components/authoring.tsx
@@ -65,6 +65,7 @@ export const defaultAuthoring: ConnectedBioAuthoring = {
   },
   breeding: {
     instructions: "",
+    enableInspectGametes: true,
     enableColorChart: true,
     enableGenotypeChart: true,
     enableSexChart: true

--- a/src/components/spaces/breeding/breeding-container.tsx
+++ b/src/components/spaces/breeding/breeding-container.tsx
@@ -44,7 +44,7 @@ export class BreedingContainer extends BaseComponent<IProps, IState> {
     const showingNesting = breeding.breedingNestPairId === undefined;
     const breedButtonClass = "breed " + (showingNesting && breeding.interactionMode === "breed" ?
       "sticky-breed " : "sticky-breed-off ");
-    const gametesButtonClass = "gametes" + (showingNesting ? " disabled" : "");
+    const gametesButtonClass = "gametes" + (showingNesting || !breeding.enableInspectGametes ? " disabled" : "");
     const inspectButtonClass = (breeding.interactionMode === "inspect" ? "sticky" : "sticky-off")
                           + (!showingNesting ? " disabled" : "");
     const collectButtonClass = (breeding.interactionMode === "select" ? "sticky-alt" : "sticky-alt-off")


### PR DESCRIPTION
This was bypassed previously because at the time the show/hide gametes button was always disabled.  These changes allow the authoring settings to take effect.