### PR TITLE
Add gamete hover effects in breeding view

### DIFF
--- a/src/components/colors.scss
+++ b/src/components/colors.scss
@@ -24,4 +24,6 @@
   colorDataMouseBrownLightRep: $color-data-mousebrown-light-rep;
   colorDataMouseBrownMediumRep: $color-data-mousebrown-medium-rep;
   colorDataMouseBrownDarkRep: $color-data-mousebrown-dark-rep;
+
+  gameteArrowColor: $color-nav-shamrock-dark1;
 }

--- a/src/components/spaces/breeding/arrow-panel.sass
+++ b/src/components/spaces/breeding/arrow-panel.sass
@@ -1,0 +1,11 @@
+.arrow-panel
+  height: 130px
+  width: 300px
+  position: absolute
+  top: 168px
+  pointer-events: none
+  z-index: 5
+  .arrow
+    transition-duration: .25s
+    &.hide
+      opacity: 0

--- a/src/components/spaces/breeding/arrow-panel.tsx
+++ b/src/components/spaces/breeding/arrow-panel.tsx
@@ -25,14 +25,14 @@ export class ArrowPanel extends BaseComponent<IProps, IState> {
     return(
       <div className="arrow-panel">
         <svg height={130} width={300}>
-          {this.renderArrowCurve()}
-          {this.renderArrowHead()}
+          {this.renderArrowCurves()}
+          {this.renderArrowHeads()}
         </svg>
       </div>
     );
   }
 
-  private renderArrowCurve = () => {
+  private renderArrowCurves = () => {
     return(
       this.props.arrows.map((arrow, i) => {
         const { startX, startY, endX, endY } = arrow;
@@ -54,7 +54,7 @@ export class ArrowPanel extends BaseComponent<IProps, IState> {
     );
   }
 
-  private renderArrowHead = () => {
+  private renderArrowHeads = () => {
     return(
       this.props.arrows.map((arrow, i) => {
         const { endX, endY } = arrow;

--- a/src/components/spaces/breeding/arrow-panel.tsx
+++ b/src/components/spaces/breeding/arrow-panel.tsx
@@ -1,0 +1,76 @@
+import * as React from "react";
+import { BaseComponent, IBaseProps } from "../../base";
+// @ts-ignore
+import * as colors from "../../../components/colors.scss";
+import "./arrow-panel.sass";
+
+export interface ArrowInfo {
+  startX: number;
+  endX: number;
+  startY: number;
+  endY: number;
+  headRotation: number;
+  visible: boolean;
+}
+
+interface IProps extends IBaseProps {
+  arrows: ArrowInfo[];
+}
+interface IState {}
+
+export class ArrowPanel extends BaseComponent<IProps, IState> {
+
+  public render() {
+
+    return(
+      <div className="arrow-panel">
+        <svg height={130} width={300}>
+          {this.renderArrowCurve()}
+          {this.renderArrowHead()}
+        </svg>
+      </div>
+    );
+  }
+
+  private renderArrowCurve = () => {
+    return(
+      this.props.arrows.map((arrow, i) => {
+        const { startX, startY, endX, endY } = arrow;
+        const controlPt1X = startX + (Math.abs(endX - startX)) * .2 * (endX > startX ? 1 : -1);
+        const controlPt2X = endX - (Math.abs(endX - startX)) * .2 * (endX > startX ? 1 : -1);
+        const path = `M${startX},${startY} C${controlPt1X},${endY / 2} ${controlPt2X},${endY / 2} ${endX},${endY}`;
+        return (
+          <path
+            d={path}
+            fill="none"
+            stroke={colors.gameteArrowColor}
+            strokeWidth={5}
+            strokeDasharray={5}
+            className={`arrow ${arrow.visible ? "" : "hide"}`}
+            key={"path" + i}
+          />
+        );
+      })
+    );
+  }
+
+  private renderArrowHead = () => {
+    return(
+      this.props.arrows.map((arrow, i) => {
+        const { endX, endY } = arrow;
+        const points = `${endX - 5},${endY} ${endX},${endY + 10} ${endX + 5},${endY}`;
+        return (
+          <polygon
+            points={points}
+            fill={colors.gameteArrowColor}
+            stroke={colors.gameteArrowColor}
+            strokeWidth={1}
+            className={`arrow ${arrow.visible ? "" : "hide"}`}
+            key={"polygon" + i}
+            transform={`rotate(${arrow.headRotation} ${endX} ${endY + 5})`}
+          />
+        );
+      })
+    );
+  }
+}

--- a/src/components/spaces/breeding/breeding-view.sass
+++ b/src/components/spaces/breeding/breeding-view.sass
@@ -32,9 +32,9 @@
       background-color: $color-simdata-brick-light3
       top: 6px
       &.mother
-        left: 55px
+        left: 59px
       &.father
-        left: 246px
+        left: 242px
 
     .gametes-message
       position: absolute
@@ -50,6 +50,7 @@
       display: flex
       flex-direction: column
       align-items: center
+      width: 100px
       z-index: 1
       &.mother
         padding-left: 61px
@@ -67,27 +68,51 @@
       .gametes
         display: flex
         flex-direction: row
+        justify-content: center
+        align-items: center
+        margin-top: 4px
         .gamete
           display: flex
           flex-direction: column
-          justify-content: center
           align-items: center
           color: $color-nav-cinder-dark2
-          margin: 1px
           font-size: 10px
+          width: 20px
+          height: 45px
+          &:hover .hover-view
+            opacity: .75
+            height: 45px
+          &:hover .icon.egg
+            background-image: url("../../../assets/icons/egg-hi.svg")
+          &:hover .icon.sperm
+            background-image: url("../../../assets/icons/sperm-hi.svg")
           .icon
             width: 16px
             height: 16px
-            margin-bottom: 2px
-            transition-duration: $fade-time
+            margin-bottom: 1px
+            margin-top: 2px
+            transition-duration: .25s
             &.egg
               background-image: url("../../../assets/icons/egg.svg")
-              &:hover
+              &.highlight
                 background-image: url("../../../assets/icons/egg-hi.svg")
             &.sperm
               background-image: url("../../../assets/icons/sperm.svg")
-              &:hover
+              &.highlight
                 background-image: url("../../../assets/icons/sperm-hi.svg")
+          .hover-view
+            transition-duration: .25s
+            z-index: -1
+            position: absolute
+            background-color: $color-nav-shamrock-light1
+            opacity: 0
+            width: 20px
+            height: 35px
+            border-radius: 10px
+            &.show
+              opacity: .75
+            &.tall
+              height: 45px
 
     .breed-button-container
       padding-top: 30px
@@ -185,10 +210,9 @@
         margin: 32px 0 -11px 0
         transition: all 0.5s
         animation: push-down 0.8s ease
-
-        .stacked-organism
-          margin: -6px;
-        .stacked-organism:nth-child(even)
+        .offspring-container
+          margin: -6px
+        .offspring-container:nth-child(even)
           margin-top: 10px
           z-index: 2
 

--- a/src/components/spaces/breeding/breeding-view.tsx
+++ b/src/components/spaces/breeding/breeding-view.tsx
@@ -63,7 +63,7 @@ export class BreedingView extends BaseComponent<IProps, IState> {
             Mother
             <div className="parent-image"
                  onMouseEnter={this.handleParentHoverEnter(0)}
-                 onMouseLeave={this.handleParentHoverExit(0)}>
+                 onMouseLeave={this.handleParentHoverExit}>
               <StackedOrganism
                 organism={mother}
                 organismImages={[mother.nestImage]}
@@ -93,7 +93,7 @@ export class BreedingView extends BaseComponent<IProps, IState> {
             Father
             <div className="parent-image"
                  onMouseEnter={this.handleParentHoverEnter(1)}
-                 onMouseLeave={this.handleParentHoverExit(1)}>
+                 onMouseLeave={this.handleParentHoverExit}>
               <StackedOrganism
                 organism={father}
                 organismImages={[father.nestImage]}
@@ -147,7 +147,7 @@ export class BreedingView extends BaseComponent<IProps, IState> {
                                           ? this.handleOffspringHoverEnter(j)
                                           : undefined}
                             onMouseLeave={currentLitter === (litterNum - 1)
-                                          ? this.handleOffspringHoverExit(j)
+                                          ? this.handleOffspringHoverExit
                                           : undefined}
                             key={"org-cont" + j}>
                             <StackedOrganism
@@ -231,7 +231,7 @@ export class BreedingView extends BaseComponent<IProps, IState> {
         return(
           <div className="gamete" key={i} style={{marginTop: offset}}
                onMouseEnter={this.handleOffspringHoverEnter(position)}
-               onMouseLeave={this.handleOffspringHoverExit(position)}>
+               onMouseLeave={this.handleOffspringHoverExit}>
             <div className={gameteViewClass} />
             <div className={gameteIconClass} />
             <div className="info-data" dangerouslySetInnerHTML={{
@@ -246,13 +246,13 @@ export class BreedingView extends BaseComponent<IProps, IState> {
   private handleOffspringHoverEnter = (index: number) => () => {
     this.setState({offspringHightlightIndex: index});
   }
-  private handleOffspringHoverExit = (index: number) => () => {
+  private handleOffspringHoverExit = () => {
     this.setState({offspringHightlightIndex: -1});
   }
   private handleParentHoverEnter = (index: number) => () => {
     this.setState({parentHightlightIndex: index});
   }
-  private handleParentHoverExit = (index: number) => () => {
+  private handleParentHoverExit = () => {
     this.setState({parentHightlightIndex: -1});
   }
 

--- a/src/components/spaces/breeding/breeding-view.tsx
+++ b/src/components/spaces/breeding/breeding-view.tsx
@@ -69,7 +69,7 @@ export class BreedingView extends BaseComponent<IProps, IState> {
                 organismImages={[mother.nestImage]}
                 height={90}
                 showSelection={false}
-                showGameteSelectionOnHover={breeding.showGametes}
+                showGameteSelection={breeding.showGametes && this.state.parentHightlightIndex === 0}
                 showSex={breeding.showSexStack}
                 showHetero={breeding.showHeteroStack}
                 showLabel={breeding.showGametes}
@@ -100,7 +100,7 @@ export class BreedingView extends BaseComponent<IProps, IState> {
                 height={90}
                 flipped={true}
                 showSelection={false}
-                showGameteSelectionOnHover={breeding.showGametes}
+                showGameteSelection={breeding.showGametes && this.state.parentHightlightIndex === 1}
                 showSex={breeding.showSexStack}
                 showHetero={breeding.showHeteroStack}
                 showLabel={breeding.showGametes}
@@ -156,7 +156,6 @@ export class BreedingView extends BaseComponent<IProps, IState> {
                               organismImages={[org.nestImage]}
                               height={60}
                               showSelection={false}
-                              showGameteSelectionOnHover={breeding.showGametes && (currentLitter === (litterNum - 1))}
                               showGameteSelection={breeding.showGametes
                                                   && currentLitter === (litterNum - 1)
                                                   && j === this.state.offspringHightlightIndex}

--- a/src/components/stacked-organism.sass
+++ b/src/components/stacked-organism.sass
@@ -5,6 +5,8 @@
 
   &:hover .selection-stack.show
     opacity: 1
+  &:hover .gamete-view-stack
+    opacity: .75
 
   .selection-stack
     position: absolute
@@ -36,6 +38,13 @@
     transition-duration: .25s
     &.show
       opacity: 1
+  .gamete-view-stack
+    border-radius: 50%
+    opacity: 0
+    transition-duration: .25s
+    background-color: $color-nav-shamrock-light1
+    &.show
+      opacity: .75
   .genotype-label
     position: absolute
     color: $color-nav-cinder-dark2

--- a/src/components/stacked-organism.tsx
+++ b/src/components/stacked-organism.tsx
@@ -9,6 +9,8 @@ interface IProps {
   height: number;
   flipped?: boolean;
   showSelection: boolean;
+  showGameteSelectionOnHover?: boolean;
+  showGameteSelection?: boolean;
   showSex: boolean;
   showHetero: boolean;
   showLabel?: boolean;
@@ -23,6 +25,7 @@ const selectionImage =  path + "select-stack.png";
 
 export const StackedOrganism: React.SFC<IProps> = (props) => {
   const selectionClass = "selection-stack " + (props.showSelection ? "show" : "");
+  const gameteViewClass = "gamete-view-stack " + (props.showGameteSelection ? "show" : "");
   const heteroClass = "hetero-stack " + ((props.showHetero && props.organism.isHeterozygote) ? "show" : "");
   const sexImage = props.organism.sex === "female" ? femaleSexImage : maleSexImage;
   const sexClass = "sex-stack " + (props.showSex ? "show" : "");
@@ -40,6 +43,10 @@ export const StackedOrganism: React.SFC<IProps> = (props) => {
 
   return (
     <div className="stacked-organism" style={fullSize}>
+      {
+        (props.showGameteSelection || props.showGameteSelectionOnHover)
+        && <div className={gameteViewClass} style={fullSize} data-test="gamete-view" />
+      }
       { props.showLabel && <div className={labelClass} dangerouslySetInnerHTML={{ __html: label }}/> }
       <img src={selectionImage} className={selectionClass} style={fullSize} data-test="selection-image" />
       {

--- a/src/components/stacked-organism.tsx
+++ b/src/components/stacked-organism.tsx
@@ -9,7 +9,6 @@ interface IProps {
   height: number;
   flipped?: boolean;
   showSelection: boolean;
-  showGameteSelectionOnHover?: boolean;
   showGameteSelection?: boolean;
   showSex: boolean;
   showHetero: boolean;
@@ -44,7 +43,7 @@ export const StackedOrganism: React.SFC<IProps> = (props) => {
   return (
     <div className="stacked-organism" style={fullSize}>
       {
-        (props.showGameteSelection || props.showGameteSelectionOnHover)
+        (props.showGameteSelection)
         && <div className={gameteViewClass} style={fullSize} data-test="gamete-view" />
       }
       { props.showLabel && <div className={labelClass} dangerouslySetInnerHTML={{ __html: label }}/> }


### PR DESCRIPTION
Add gamete hover effects into the breeding view when show gametes option is turned on.  Notes:
- a new `ArrowPanel` component takes in an array of `ArrowInfo` objects which specify each hover arrow and then renders the full set of arrows
- additional highlight properties have been added to the React state in the `BreedingView`component to help manage what object a user is hovering over and the subsequent effects that this has on other parts of the UI 
- additional props were added to the `StackedOrganism` to support the new mouse hover effects