### PR TITLE
Fix incorrect parenting of CSS classes

### DIFF
--- a/src/components/spaces/populations/populations-container.sass
+++ b/src/components/spaces/populations/populations-container.sass
@@ -165,15 +165,15 @@
       color: $color-nav-cinder
       background-color: $color-nav-cinder-light3
 
-  .populations-container
-    cursor: auto
-    &.select
-      cursor: url('../../../assets/collect-cursor.png') 27 20, auto
-    &.inspect
-      cursor: url('../../../assets/inspect-cursor.png') 6 5, auto
+.populations-container
+  cursor: auto
+  &.select
+    cursor: url('../../../assets/collect-cursor.png') 27 20, auto
+  &.inspect
+    cursor: url('../../../assets/inspect-cursor.png') 6 5, auto
 
-  .populations-environment
-    .bubble .content .details .agent-property-value
-      clear: left
-      float: left
-      padding: 3px 0 10px 10px
+.populations-environment
+  .bubble .content .details .agent-property-value
+    clear: left
+    float: left
+    padding: 3px 0 10px 10px


### PR DESCRIPTION
One more fix that backtracks an earlier change and unparents a couple of CSS classes from the population level toolbar.  The effect in this case was that we lost the inspect and collect cursors at the population level.