### PR TITLE
Fix authoring page scrolling

### DIFF
--- a/src/components/app.sass
+++ b/src/components/app.sass
@@ -16,6 +16,7 @@
     position: initial
     height: 100vh
     overflow: scroll
+    align-items: stretch
 
 .outer-scale-wrapper
   background-color: white


### PR DESCRIPTION
Having a flex box with centered content was resulting in only a portion of the page content from being accessible within a container with scrollbar.  This quick fix replaces the `align-items: center` so all of the content appears in the scroll container. 