### PR TITLE
prevent inspection of inactive litter mice

### DIFF
--- a/src/components/spaces/breeding/breeding-view.tsx
+++ b/src/components/spaces/breeding/breeding-view.tsx
@@ -164,7 +164,8 @@ export class BreedingView extends BaseComponent<IProps, IState> {
                               showGameteSelection={showGametes
                                                   && currentLitter === (litterNum - 1)
                                                   && j === this.state.offspringHightlightIndex}
-                              showInspect={breeding.interactionMode === "inspect"}
+                              showInspect={breeding.interactionMode === "inspect"
+                                          && currentLitter === (litterNum - 1)}
                               showSex={breeding.showSexStack}
                               showHetero={breeding.showHeteroStack}
                               showLabel={showGametes}


### PR DESCRIPTION
Prevent inspection of mice that are not in the active litter (this same rule applies to gamete inspection and collection and needed to be implemented for inspection as well).