### PR TITLE
Add breed level collection of parent and offspring mice

### DIFF
--- a/src/components/spaces/breeding/breeding-container.tsx
+++ b/src/components/spaces/breeding/breeding-container.tsx
@@ -46,11 +46,10 @@ export class BreedingContainer extends BaseComponent<IProps, IState> {
       "sticky-breed " : "sticky-breed-off ");
     const gametesButtonClass = "gametes" + (showingNesting || !breeding.enableInspectGametes ? " disabled" : "");
     const inspectButtonClass = (breeding.interactionMode === "inspect" ? "sticky" : "sticky-off");
-    const collectButtonClass = (breeding.interactionMode === "select" ? "sticky-alt" : "sticky-alt-off")
-                          + (!showingNesting ? " disabled" : "");
+    const collectButtonClass = (breeding.interactionMode === "select" ? "sticky-alt" : "sticky-alt-off");
     const containerClass = "breeding-container"
                     + (breeding.interactionMode === "inspect" ? " inspect" : "")
-                    + ((breeding.interactionMode === "select" && showingNesting) ? " select" : "")
+                    + (breeding.interactionMode === "select" ? " select" : "")
                     + ((breeding.interactionMode === "breed" && showingNesting) ? " breed" : "")
                     + ((breeding.interactionMode === "gametes" && !showingNesting) ? " gametes" : "");
 

--- a/src/models/backpack-mouse.ts
+++ b/src/models/backpack-mouse.ts
@@ -17,7 +17,8 @@ export const BackpackMouse = types
     id: types.optional(types.identifier, () => uuid()),
     sex: SexTypeEnum,
     genotype: GenotypeEnum,
-    label: ""
+    label: "",
+    originMouseRefId: types.maybe(types.string),
   })
   .views(self => ({
     get baseColor(): ColorType {
@@ -50,6 +51,9 @@ export const BackpackMouse = types
           return "assets/mouse_tan_nest.png";
       }
     },
+    get nestOutlineImage(): string {
+      return "assets/curriculum/mouse/breeding/nesting/nest_mouse_outline.png";
+    },
     get zoomImage(): string {
       switch (self.genotype) {
         case "RR":
@@ -63,6 +67,8 @@ export const BackpackMouse = types
     get isHeterozygote(): boolean {
       return (self.genotype === "RC" || self.genotype === "CR");
     },
+  }))
+  .actions(self => ({
     setLabel(val: string) {
       self.label = val;
     }

--- a/src/models/backpack.ts
+++ b/src/models/backpack.ts
@@ -25,7 +25,11 @@ export const BackpackModel = types
 
       isSelected(mouse?: BackpackMouseType) {
         return self.activeMouse && self.activeMouse === mouse;
-      }
+      },
+
+      cloneExists(id: string | undefined): boolean {
+        return (id && self.collectedMice.find(bpMouse => bpMouse.originMouseRefId === id) ? true : false);
+      },
     };
   })
   .actions((self) => {

--- a/src/models/backpack.ts
+++ b/src/models/backpack.ts
@@ -28,7 +28,7 @@ export const BackpackModel = types
       },
 
       cloneExists(id: string | undefined): boolean {
-        return (id && self.collectedMice.find(bpMouse => bpMouse.originMouseRefId === id) ? true : false);
+        return (self.collectedMice.some(bpMouse => bpMouse.originMouseRefId === id));
       },
     };
   })

--- a/src/models/spaces/breeding/breeding.ts
+++ b/src/models/spaces/breeding/breeding.ts
@@ -77,8 +77,6 @@ export const NestPair = types.model({
   id: types.optional(types.identifier, () => uuid()),
   leftMouse: BackpackMouse,
   rightMouse: BackpackMouse,
-  leftMouseBackpackId: types.maybe(types.string),
-  rightMouseBackpackId: types.maybe(types.string),
   label: types.string,
   currentBreeding: false,
   hasBeenVisited: false,
@@ -126,12 +124,6 @@ export const NestPair = types.model({
   }
 }))
 .actions(self => ({
-  setLeftMouseBackpackId(id: string) {
-    self.leftMouseBackpackId = id;
-  },
-  setRightMouseBackpackId(id: string) {
-    self.rightMouseBackpackId = id;
-  },
   setCurrentBreeding(val: boolean) {
     self.currentBreeding = val;
     if (val) {
@@ -304,19 +296,6 @@ export const BreedingModel = types
         self.interactionMode = "none";
       } else {
         self.interactionMode = mode;
-      }
-    },
-
-    setNestPairLeftMouseBackpackId(nestPairId: string, backpackId: string) {
-      const nestPair = self.nestPairs.find(pair => pair.id === nestPairId);
-      if (nestPair) {
-        nestPair.setLeftMouseBackpackId(backpackId);
-      }
-    },
-    setNestPairRightMouseBackpackId(nestPairId: string, backpackId: string) {
-      const nestPair = self.nestPairs.find(pair => pair.id === nestPairId);
-      if (nestPair) {
-        nestPair.setRightMouseBackpackId(backpackId);
       }
     },
     clearNestPairActiveBreeding() {


### PR DESCRIPTION
Add breed level collection of parent/offspring mice in both the nest and breeding views.  When collected, the mouse is cloned as a newly created backpack mouse and added to the backpack.  A reference to the original collected mouse is stored in the backpack store to allow highlighting the mice at the breed level.  The previous implementation of the nest view collection has been removed and replaced with this new model (so we no longer store a reference to the backpack mouse with the NestPair).