### PR TITLE
Fix nucleus initialization

### DIFF
--- a/src/components/spaces/organisms/nucleus-view.tsx
+++ b/src/components/spaces/organisms/nucleus-view.tsx
@@ -5,6 +5,7 @@ import { BaseComponent, IBaseProps } from "../../base";
 import "./organism-view.sass";
 import { onAction, ISerializedActionCall } from "mobx-state-tree";
 import { ChromIdType } from "../../../models/spaces/organisms/organisms-row";
+import { IDisposer } from "mobx-state-tree/dist/utils";
 
 type ChromosomeState = "expanded" | "condensed" | "paired";
 type OutlineState = "condensedOutline" | "pairedOutline";
@@ -67,6 +68,7 @@ interface IState {
   hoveredChromosome?: ChromIdType;
 }
 
+let timer: number;
 const animationTime = 3000;
 
 @inject("stores")
@@ -77,8 +79,15 @@ export class NucleusView extends BaseComponent<IProps, IState> {
     previousChromosomeState: "expanded" as ChromosomeState
   };
 
+  private disposer: IDisposer;
+
   public componentWillMount() {
-    onAction(this.stores.organisms, this.updatingModel);
+    this.disposer = onAction(this.stores.organisms, this.updatingModel);
+  }
+
+  public componentWillUnmount() {
+    if (this.disposer) this.disposer();
+    if (timer) (window as any).clearTimeout(timer);
   }
 
   public render() {
@@ -130,7 +139,7 @@ export class NucleusView extends BaseComponent<IProps, IState> {
   // The `onNucleusAnimating` call just disables the menu buttons
   private startAnimation = () => {
     this.props.onNucleusAnimating(true);
-    (window as any).setTimeout(() => {
+    timer = (window as any).setTimeout(() => {
       this.setState({previousChromosomeState: this.chromosomeState});
       this.props.onNucleusAnimating(false);
     }, animationTime);

--- a/src/components/spaces/organisms/nucleus-view.tsx
+++ b/src/components/spaces/organisms/nucleus-view.tsx
@@ -230,13 +230,17 @@ export class NucleusView extends BaseComponent<IProps, IState> {
   }
 
   private setHoveredChromosome = (name: ChromIdType) => () => {
-    if (this.row.mode === "inspect") {
+    const isAnimating = this.chromosomeState !== this.state.previousChromosomeState;
+    if (this.row.mode === "inspect" && !isAnimating) {
       this.setState({hoveredChromosome: name});
     }
   }
 
   private unsetHoveredChromosome = () => {
-    this.setState({hoveredChromosome: undefined});
+    const isAnimating = this.chromosomeState !== this.state.previousChromosomeState;
+    if (!isAnimating) {
+      this.setState({hoveredChromosome: undefined});
+    }
   }
 
   private setActiveChromosome = (name: ChromIdType) => () => {

--- a/src/components/spaces/organisms/nucleus-view.tsx
+++ b/src/components/spaces/organisms/nucleus-view.tsx
@@ -81,6 +81,14 @@ export class NucleusView extends BaseComponent<IProps, IState> {
 
   private disposer: IDisposer;
 
+  constructor(props: IProps) {
+    super(props);
+
+    this.state = {
+      previousChromosomeState: this.chromosomeState
+    };
+  }
+
   public componentWillMount() {
     this.disposer = onAction(this.stores.organisms, this.updatingModel);
   }

--- a/src/components/spaces/organisms/organisms-container.tsx
+++ b/src/components/spaces/organisms/organisms-container.tsx
@@ -95,7 +95,7 @@ export class OrganismsContainer extends BaseComponent<IProps, IState> {
   // We explicitly pass down organismsRow and zoomLevel separately
   private organismZoomedView = (organismsRow: OrganismsRowModelType, zoomLevel: ZoomLevelType, rowIndex: number,
                                 mode: ModeType) => {
-    const { organismsMouse } = organismsRow;
+    const { organismsMouse, previousZoomLevel } = organismsRow;
     const width = DEFAULT_MODEL_WIDTH;
     const { isZoomingIntoOrg, cellModelLoaded } = this.state;
     const cellClassName = `cell-zoom-panel`;
@@ -103,7 +103,8 @@ export class OrganismsContainer extends BaseComponent<IProps, IState> {
     return (
       <div className="organism-stacker">
         {
-          (zoomLevel === "organism" || isZoomingIntoOrg || !cellModelLoaded) &&
+          (zoomLevel === "organism" || isZoomingIntoOrg ||
+            (previousZoomLevel as unknown as string === "organism" && !cellModelLoaded)) &&
           <OrganismView
             backpackMouse={organismsMouse && organismsMouse.backpackMouse}
             zoomIn={isZoomingIntoOrg}

--- a/src/models/spaces/organisms/organisms-row.ts
+++ b/src/models/spaces/organisms/organisms-row.ts
@@ -38,6 +38,9 @@ export const OrganismsRowModel = types
     nucleusState: types.optional(NucleusState, "expanded"),
     selectedChromosome: types.maybe(ChromosomeId)
   })
+  .volatile(self => ({
+    previousZoomLevel: types.maybe(ZoomLevel),
+  }))
   .views(self => ({
     get currentData(): ChartDataModelType {
       const chartDataSets: ChartDataSetModelType[] = [];
@@ -98,6 +101,9 @@ export const OrganismsRowModel = types
         self.selectedOrganelle = organelle;
       },
       setZoomLevel(zoomLevel: ZoomLevelType) {
+        if (self.zoomLevel) {
+          self.previousZoomLevel = self.zoomLevel as any;
+        }
         self.zoomLevel = zoomLevel;
 
         // reset stuff between levels


### PR DESCRIPTION
This fixes several issues seen in the nucleus:

1. Zooming to the nucleus, and then either saving state and reloading the page, or going to another space and coming back, will result in seeing the mouse image covering up the nucleus
2. Condensing and/or pairing the chromatin, then leaving the space and coming back will result in animations when you return
3. If you move your cursor in and out of the frame during animation, animation will stutter
3. Console errors after leaving and returning to the nucleus, and then doing anything to the chromatin

The fix can be seen at http://connected-bio-spaces.concord.org/branch/fix-nucleus-initialization/

If you want to test saving state without LARA, use http://connected-bio-spaces.concord.org/branch/fix-nucleus-initialization/?saveToLocalStore