### PR TITLE
Fix click on inactive litter mouse

### DIFF
--- a/src/components/spaces/breeding/breeding-view.tsx
+++ b/src/components/spaces/breeding/breeding-view.tsx
@@ -164,7 +164,9 @@ export class BreedingView extends BaseComponent<IProps, IState> {
                             onMouseLeave={currentLitter === (litterNum - 1)
                                           ? this.handleOffspringHoverExit
                                           : undefined}
-                            onClick={this.handleClickMouse(org, id, litters.length - i - 1, false)}
+                            onClick={currentLitter === (litterNum - 1)
+                                     ? this.handleClickMouse(org, id, litters.length - i - 1, false)
+                                     : undefined}
                             key={"org-cont" + j}>
                             <StackedOrganism
                               key={"org" + j}


### PR DESCRIPTION
The PR fixes the following bug discovered in QA: user could click on inactive mice in the litter view and collect/inspect them.  Clicks on inactive mice in the litter view are now ignored.