### PR TITLE
Clear inspection when reset litter while inspecting mouse in litter

### DIFF
--- a/src/models/spaces/breeding/breeding.ts
+++ b/src/models/spaces/breeding/breeding.ts
@@ -281,6 +281,13 @@ export const BreedingModel = types
       const nestPair = self.nestPairs.find(pair => pair.id === self.breedingNestPairId);
       if (!nestPair) return;
       nestPair.clearLitters();
+      // if we're inspecting a litter mouse, clear inspection
+      if ((self.inspectInfo.type === "gamete" || self.inspectInfo.type === "organism")
+          && self.inspectInfo.nestPairId === self.breedingNestPairId
+          && !self.inspectInfo.isParent) {
+        self.inspectInfo.litterIndex = -1;
+        self.inspectInfo.type = "none";
+      }
     },
 
     setShowSexStack(show: boolean) {


### PR DESCRIPTION
This fixes a bug that was seen during the all-hands demo.  If the user is inspecting a litter mouse and the reset litter button is pressed, we hit an exception (as we were trying to inspect a mouse that no longer exists).  This PR clears the inspection info if we are inspecting a litter mouse and the clear litter button is pressed.