### PR TITLE
Restore data panel if user began breeding

### DIFF
--- a/src/models/spaces/breeding/breeding.ts
+++ b/src/models/spaces/breeding/breeding.ts
@@ -244,6 +244,9 @@ export function createBreedingModel(breedingProps: any) {
       };
     });
   }
+  if (breedingProps.nestPairs && breedingProps.nestPairs.some((pair: INestPair) => pair.hasBeenVisited)) {
+    breedingProps.rightPanel = "data";
+  }
   breedingProps.inspectInfo = InspectInfo.create({nestPairId: "", organismId: "", litterIndex: 0, isParent: false, });
   return BreedingModel.create(breedingProps);
 }


### PR DESCRIPTION
Restore the data panel on the breeding level if we open the user save state and they have begun breeding.  I went with checking if one of the nest pairs had been visited via the `hasBeenVisited` property (rather than checking if a litter array contains mice) since checking `hasBeenVisited` will also handle the following cases:
-user has bred mice and hit the reset button
-user has selected one or more pairs that they want to mark for breeding but hasn't hit breed button yet
Both felt like valid reasons to restore the data panel.  However, I'm open to changing this if we put it in front of users and it is confusing.