### PR TITLE
Graph updates

### DIFF
--- a/src/models/spaces/breeding/breeding.ts
+++ b/src/models/spaces/breeding/breeding.ts
@@ -272,6 +272,12 @@ export const BreedingModel = types
   })
   .actions(self => ({
 
+    afterCreate() {
+      if (!self.instructions) {
+        self.rightPanel = "data";
+      }
+    },
+
     breedLitter() {
       const nestPair = self.nestPairs.find(pair => pair.id === self.breedingNestPairId);
       if (!nestPair) return;

--- a/src/models/spaces/organisms/organisms-space.ts
+++ b/src/models/spaces/organisms/organisms-space.ts
@@ -200,6 +200,15 @@ export const OrganismsSpaceModel = types
     }
 
     return {
+
+      afterCreate() {
+        if (!self.instructions) {
+          if (self.rows[0]) {
+            self.rows[0].rightPanel = "data";
+          }
+        }
+      },
+
       clearRowBackpackMouse,
       setRowBackpackMouse(rowIndex: number, backpackMouse: BackpackMouseType) {
         let organismsMouse = self.organismsMice.find((existingOrganismsMouse) => {

--- a/src/models/spaces/populations/populations.ts
+++ b/src/models/spaces/populations/populations.ts
@@ -73,6 +73,13 @@ export const PopulationsModel = types
         }
       },
       actions: {
+
+        afterCreate() {
+          if (!self.instructions) {
+            self.rightPanel = "data";
+          }
+        },
+
         togglePlay() {
           if (!self.isPlaying) {
             self.model.interactive.play();


### PR DESCRIPTION
Adds new annotations on mutation and inheritance switching, and makes the graph panel the default for every space if no instructions are shown.

A tiny bit of smarts is added to make the graph annotations fit next to each other if they are toggled in short succession. It could definitely be smarter-still (you'll still get overlaps if things are too close too often), but, OTOH, if students are toggling things all the time in short succession, they're using it wrong...

<img width="1048" alt="Screen Shot 2020-04-06 at 1 48 16 PM" src="https://user-images.githubusercontent.com/35721/78588971-77eab580-780d-11ea-91f2-ab96114b1f9e.png">
