### PR TITLE
Fix zoom issues

### DIFF
--- a/src/components/spaces/organisms-space.tsx
+++ b/src/components/spaces/organisms-space.tsx
@@ -16,13 +16,19 @@ import { CollectButtonComponent } from "../collect-button";
 import ChromosomeViewer from "./organisms/chromosome-viewer";
 
 interface IProps extends IBaseProps {}
-interface IState {}
+interface IState {
+  isZooming: boolean;
+}
 
 @inject("stores")
 @observer
 export class OrganismsSpaceComponent extends BaseComponent<IProps, IState> {
   constructor(props: IProps) {
     super(props);
+
+    this.state = {
+      isZooming: false
+    };
   }
 
   public render() {
@@ -168,7 +174,10 @@ export class OrganismsSpaceComponent extends BaseComponent<IProps, IState> {
         />
         <TwoUpDisplayComponent
           leftTitle="Explore: Organism"
-          leftPanel={<OrganismsContainer rowIndex={rowIndex}/>}
+          leftPanel={<OrganismsContainer
+            rowIndex={rowIndex}
+            disableZoom={this.state.isZooming}
+            notifyZooming={this.handleZooming} />}
           rightPanel={rightPanelContent}
           instructionsIconEnabled={true}
           dataIconEnabled={true}
@@ -191,6 +200,10 @@ export class OrganismsSpaceComponent extends BaseComponent<IProps, IState> {
   private clickClose = (rowIndex: number) => () => {
     const { organisms } = this.stores;
     organisms.clearRowBackpackMouse(rowIndex);
+  }
+
+  private handleZooming = (isZooming: boolean) => {
+    this.setState({isZooming});
   }
 
 }

--- a/src/components/spaces/organisms/organism-view.tsx
+++ b/src/components/spaces/organisms/organism-view.tsx
@@ -33,6 +33,11 @@ export class OrganismView extends BaseComponent<IProps, IState> {
 
   public componentDidMount() {
     this.initializeImage();
+    document.addEventListener("visibilitychange", this.handleVisibilityChange);
+  }
+
+  public componentWillUnmount() {
+    document.removeEventListener("visibilitychange", this.handleVisibilityChange);
   }
 
   public componentDidUpdate(prevProps: IProps) {
@@ -44,7 +49,7 @@ export class OrganismView extends BaseComponent<IProps, IState> {
     }
   }
 
-  private initializeImage() {
+  private initializeImage = () => {
     const { backpackMouse } = this.props;
     const mouseImage = backpackMouse && backpackMouse.zoomImage;
     if (mouseImage) {
@@ -66,16 +71,28 @@ export class OrganismView extends BaseComponent<IProps, IState> {
     }
   }
 
-  private startZoom() {
+  private startZoom = () => {
     if (!this.animator) return;
     this.animator._loopCount = 1;
     this.animator._loops = 1;
     this.animator.start();
   }
 
-  private handleAnimationFinished() {
+  private handleAnimationFinished = () => {
     this.props.onZoomInComplete && this.props.onZoomInComplete();
   }
 
   private setCanvasElRef = (element: any) => this.canvasElRef = element;
+
+  // Gifler freezes if we tab away and return.
+  private handleVisibilityChange = () => {
+    if (document.visibilityState === "visible") {
+      // If we return to being visible, that means we had tabbed away
+      // from the model, and we need to jump to the completed animation
+      if (this.animator) {
+        this.animator.stop();
+        this.handleAnimationFinished();
+      }
+    }
+  }
 }

--- a/src/components/spaces/organisms/organism-view.tsx
+++ b/src/components/spaces/organisms/organism-view.tsx
@@ -26,7 +26,7 @@ export class OrganismView extends BaseComponent<IProps, IState> {
   public render() {
     return (
       <div className="organism-view-container">
-        <canvas style={{width: "100%"}} ref={this.setCanvasElRef} />
+        <canvas key={this.props.backpackMouse ? "org" : ""} style={{width: "100%"}} ref={this.setCanvasElRef} />
       </div>
     );
   }
@@ -41,6 +41,9 @@ export class OrganismView extends BaseComponent<IProps, IState> {
   }
 
   public componentDidUpdate(prevProps: IProps) {
+    if (!this.props.backpackMouse) {
+      this.handleAnimationFinished();
+    }
     if (this.props.backpackMouse && this.props.backpackMouse !== prevProps.backpackMouse) {
       this.initializeImage();
     }

--- a/src/components/spaces/organisms/organisms-container.tsx
+++ b/src/components/spaces/organisms/organisms-container.tsx
@@ -13,6 +13,8 @@ import { DEFAULT_MODEL_WIDTH } from "../../..";
 
 interface IProps extends IBaseProps {
   rowIndex: number;
+  disableZoom: boolean;
+  notifyZooming: (isZooming: boolean) => void;
 }
 interface IState {
   zoomLevel: number;
@@ -47,7 +49,8 @@ export class OrganismsContainer extends BaseComponent<IProps, IState> {
           this.organismZoomedView(organismsRow, zoomLevel, rowIndex, mode)
         }
         <div className="organism-controls">
-          <ZoomControl handleZoom={this.zoomChange} rowIndex={rowIndex} showTargetZoom={showTargetZoom} />
+          <ZoomControl handleZoom={this.zoomChange} rowIndex={rowIndex} showTargetZoom={showTargetZoom}
+            disable={this.props.disableZoom} />
           <ManipulationControls rowIndex={rowIndex} disableNucleusControls={this.state.nucleusAnimating} />
         </div>
       </div>
@@ -79,8 +82,10 @@ export class OrganismsContainer extends BaseComponent<IProps, IState> {
         isZoomingIntoOrg: false,
         cellModelLoaded: false
       });
+      this.props.notifyZooming(false);
     } else if (zoomLevel === "cell" && current === 0) {
       this.setState({isZoomingIntoOrg: true});
+      this.props.notifyZooming(true);
     }
     organismsRow.setZoomLevel(defaultZoomLevelByIndex[nextIdx]);
   }
@@ -133,6 +138,7 @@ export class OrganismsContainer extends BaseComponent<IProps, IState> {
 
   private handleOrgZoomInComplete = () => {
     this.setState({isZoomingIntoOrg: false});
+    this.props.notifyZooming(false);
   }
 
   private cellModelLoaded = () => {

--- a/src/components/zoom-control.tsx
+++ b/src/components/zoom-control.tsx
@@ -9,6 +9,7 @@ interface IProps extends IBaseProps {
   handleZoom: (zoomLevel: number) => void;
   rowIndex: number;
   showTargetZoom: boolean;
+  disable: boolean;
 }
 interface IState {}
 
@@ -51,9 +52,9 @@ export class ZoomControl extends BaseComponent<IProps, IState> {
 
   private getZoomClass = (enabledZooms: ZoomLevelType[]) => {
     const { organisms } = this.stores;
-    const { rowIndex } = this.props;
+    const { rowIndex, disable } = this.props;
     const row = organisms.rows[rowIndex];
-    if (row.zoomLevel === "cell" && !organisms.showZoomToNucleus && !organisms.showZoomToReceptor) {
+    if (disable || row.zoomLevel === "cell" && !organisms.showZoomToNucleus && !organisms.showZoomToReceptor) {
       return " disabled";
     }
     const disabledClass = !row.organismsMouse || enabledZooms.indexOf(row.zoomLevel) === -1 ? " disabled" : "";

--- a/src/models/spaces/organisms/organisms-space.ts
+++ b/src/models/spaces/organisms/organisms-space.ts
@@ -190,7 +190,14 @@ export const OrganismsSpaceModel = types
   .actions((self) => {
     function clearRowBackpackMouse(rowIndex: number) {
       const clearedOrganismsMouse = self.rows[rowIndex].organismsMouse;
-      self.rows[rowIndex] = OrganismsRowModel.create();
+
+      // keep right panel as-is, unless it's on "information" which doesn't make sense for no org
+      let rightPanel: RightPanelType = (rowIndex === 0 && self.instructions) ? "instructions" : "data";
+      if (self.rows[rowIndex] && self.rows[rowIndex].rightPanel && self.rows[rowIndex].rightPanel !== "information") {
+        rightPanel = self.rows[rowIndex].rightPanel;
+      }
+
+      self.rows[rowIndex] = OrganismsRowModel.create({ rightPanel });
 
       if (clearedOrganismsMouse) {
         if (!self.rows.some(row => row.organismsMouse === clearedOrganismsMouse)) {
@@ -220,7 +227,7 @@ export const OrganismsSpaceModel = types
         }
 
         // keep right panel as it was
-        let rightPanel: RightPanelType = rowIndex === 0 ? "instructions" : "data";
+        let rightPanel: RightPanelType = (rowIndex === 0 && self.instructions) ? "instructions" : "data";
         if (self.rows[rowIndex] && self.rows[rowIndex].rightPanel) {
           rightPanel = self.rows[rowIndex].rightPanel;
         }


### PR DESCRIPTION
This

1. Prevents users from zooming into two rows at the same time (https://www.pivotaltracker.com/story/show/169733198)
2. Handles the case where the user clicks to a different tab and back again (or otherwise changes the visibility of the window), which previously froze the animation, by having it always jump to loading the cell model when the user returns
3. Properly clear organism image when user removes it from the row at the organism level
3. Improve handling of right panel when user removes org from row