### PR TITLE
172274981 graph popups

### DIFF
--- a/src/components/charts/line-chart.tsx
+++ b/src/components/charts/line-chart.tsx
@@ -178,6 +178,17 @@ export class LineChart extends BaseComponent<ILineProps, ILineState> {
       },
       annotation: {
         annotations: chartData.formattedAnnotations
+      },
+      tooltips: {
+        enabled: true,
+        callbacks: {
+          labelColor(tooltipItem: any, chart: any) {
+            return {
+              borderColor: "rgb(255, 255, 255)",
+              backgroundColor: chart.config.data.datasets[tooltipItem.datasetIndex].borderColor
+            };
+          },
+        }
       }
     });
     const w = width ? width : 400;

--- a/src/components/charts/line-chart.tsx
+++ b/src/components/charts/line-chart.tsx
@@ -167,7 +167,10 @@ export class LineChart extends BaseComponent<ILineProps, ILineState> {
             minRotation: chartData.dataLabelRotation,
             maxRotation: chartData.dataLabelRotation,
             userCallback: (label: any) => {
-              return Math.ceil(label);
+              return (label === minMaxValues.minA1
+                      ? Math.floor(label)
+                      : Math.ceil(label)
+              );
             },
           },
           scaleLabel: {

--- a/src/components/charts/line-chart.tsx
+++ b/src/components/charts/line-chart.tsx
@@ -185,6 +185,9 @@ export class LineChart extends BaseComponent<ILineProps, ILineState> {
       tooltips: {
         enabled: true,
         callbacks: {
+          label(tooltipItems: any, data: any) {
+            return `(${tooltipItems.xLabel}, ${Math.round(tooltipItems.yLabel * 100) / 100})`;
+          },
           labelColor(tooltipItem: any, chart: any) {
             return {
               borderColor: "rgb(255, 255, 255)",

--- a/src/models/spaces/charts/chart-data-set.ts
+++ b/src/models/spaces/charts/chart-data-set.ts
@@ -228,7 +228,9 @@ export const ChartDataSetModel = types
     }
 
     function addDataPoint(a1: number, a2: number, label: string) {
-      self.dataPoints.push({ a1, a2, label });
+      if (!self.dataPoints.some(d => d.a1 === a1)) {
+        self.dataPoints.push({ a1, a2, label });
+      }
     }
 
     function updateDataPoint(pointIdx: number, newValA1: number, newValA2: number) {

--- a/src/models/spaces/charts/chart-data-set.ts
+++ b/src/models/spaces/charts/chart-data-set.ts
@@ -168,7 +168,7 @@ export const ChartDataSetModel = types
             return self.maxPoints;
           }
       } else {
-        return Math.max(...self.visibleDataPoints.map(p => p.a1));
+        return Math.max(self.initialMaxA1 ? self.initialMaxA1 : 0, ...self.visibleDataPoints.map(p => p.a1));
       }
     },
     get maxA2(): number | undefined {

--- a/src/models/spaces/charts/chart-data-set.ts
+++ b/src/models/spaces/charts/chart-data-set.ts
@@ -228,9 +228,7 @@ export const ChartDataSetModel = types
     }
 
     function addDataPoint(a1: number, a2: number, label: string) {
-      if (!self.dataPoints.some(d => d.a1 === a1)) {
-        self.dataPoints.push({ a1, a2, label });
-      }
+      self.dataPoints.push({ a1, a2, label });
     }
 
     function updateDataPoint(pointIdx: number, newValA1: number, newValA2: number) {

--- a/src/models/spaces/charts/chart-data.test.ts
+++ b/src/models/spaces/charts/chart-data.test.ts
@@ -134,19 +134,19 @@ describe("chart data model", () => {
       chart.dataSets[0].addDataPoint(i, 100 + i, "");
     }
 
-    expect(chart.dataSets[0].dataPoints.length).toEqual(200);
-    expect(chart.dataSets[0].visibleDataPoints.length).toEqual(80);   // 80 downsampled points
+    expect(chart.dataSets[0].dataPoints.length).toEqual(203);
+    expect(chart.dataSets[0].visibleDataPoints.length).toEqual(83);   // 80 downsampled points and 3 additional
 
     for (let i = 200; i < 240; i++) {
       chart.dataSets[0].addDataPoint(i, 300 + i, ""); // add 40 points
     }
 
-    expect(chart.dataSets[0].dataPoints.length).toEqual(240);
-    expect(chart.dataSets[0].visibleDataPoints.length).toEqual(80);   // 80 downsampled points
+    expect(chart.dataSets[0].dataPoints.length).toEqual(243);
+    expect(chart.dataSets[0].visibleDataPoints.length).toEqual(83);   // 80 downsampled points and 3 additional
 
     chart.dataSets[0].addDataPoint(300, 400, ""); // add 1 point
 
-    expect(chart.dataSets[0].dataPoints.length).toEqual(241);
-    expect(chart.dataSets[0].visibleDataPoints.length).toEqual(81);   // 80 downsampled points
+    expect(chart.dataSets[0].dataPoints.length).toEqual(244);
+    expect(chart.dataSets[0].visibleDataPoints.length).toEqual(84);   // 80 downsampled points and 4 additional
   });
 });

--- a/src/models/spaces/charts/chart-data.test.ts
+++ b/src/models/spaces/charts/chart-data.test.ts
@@ -128,23 +128,25 @@ describe("chart data model", () => {
   it("can downsample its visible data", () => {
     chart.dataSets[0].setMaxDataPoints(-1);
 
+    expect(chart.dataSets[0].dataPoints.length).toEqual(3); // 3 initial points
+
     for (let i = 0; i < 200; i++) {
       chart.dataSets[0].addDataPoint(i, 100 + i, "");
     }
 
-    expect(chart.dataSets[0].dataPoints.length).toEqual(203);
-    expect(chart.dataSets[0].visibleDataPoints.length).toEqual(83);   // 80 downsampled points and 3 additional
+    expect(chart.dataSets[0].dataPoints.length).toEqual(200);
+    expect(chart.dataSets[0].visibleDataPoints.length).toEqual(80);   // 80 downsampled points
 
-    for (let i = 0; i < 36; i++) {
-      chart.dataSets[0].addDataPoint(i, 300 + i, "");
+    for (let i = 200; i < 240; i++) {
+      chart.dataSets[0].addDataPoint(i, 300 + i, ""); // add 40 points
     }
-
-    expect(chart.dataSets[0].dataPoints.length).toEqual(239);
-    expect(chart.dataSets[0].visibleDataPoints.length).toEqual(119);   // 80 downsampled points and 39 additional
-
-    chart.dataSets[0].addDataPoint(0, 400, "");
 
     expect(chart.dataSets[0].dataPoints.length).toEqual(240);
     expect(chart.dataSets[0].visibleDataPoints.length).toEqual(80);   // 80 downsampled points
+
+    chart.dataSets[0].addDataPoint(300, 400, ""); // add 1 point
+
+    expect(chart.dataSets[0].dataPoints.length).toEqual(241);
+    expect(chart.dataSets[0].visibleDataPoints.length).toEqual(81);   // 80 downsampled points
   });
 });

--- a/src/models/spaces/populations/mouse-model/mouse-populations-model.ts
+++ b/src/models/spaces/populations/mouse-model/mouse-populations-model.ts
@@ -259,15 +259,6 @@ export const MousePopulationsModel = types
       return 0;
     }
 
-    Events.addEventListener(Environment.EVENTS.START, () => {
-      if (interactive) {
-        const date = interactive.environment.date;
-        if (date === 0) {
-          addData(date, interactive.getData());
-        }
-      }
-    });
-
     Events.addEventListener(Environment.EVENTS.STEP, () => {
       if (interactive) {
         const date = interactive.environment.date;


### PR DESCRIPTION
This PR adds the following improvements to the line chart in the population view:
- filter duplicate x values so that tooltip popup at t = 0 doesn't show additional, unexpected values (with present design, x represents time so we should not have multiple samples at a given x or time value).
- fix tooltip popup colors so that colors match the graph lines and legend
- prevent duplicate values in x axis labels by doing the following: set min axis value to 12 when in "show all data" mode and change rounding of min value to avoid min val and first tick having same value
- round values shown in tooltip popup to use max of 2 decimal places