### PR TITLE
Fix signal binding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15712,9 +15712,9 @@
       }
     },
     "organelle": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/organelle/-/organelle-0.0.12.tgz",
-      "integrity": "sha512-wWlvoRdduIBQAJc6gjLSnYZSJEauziPlL5x1lIPqNkYTx5MieTfCEaU0UsZKHXLTe+j+fDii48VIAnqSxS4TUw==",
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/organelle/-/organelle-0.0.13.tgz",
+      "integrity": "sha512-k9eAIb3/64FYm9pF6au7uGK1hJOHV8c+FB6FLdnNBLfwQXm7CxCK0UiMQ4CdlPvHssNA6tPl94SaHLyjwITvlA==",
       "requires": {
         "babel-polyfill": "^6.16.0",
         "fabric": "2.0.0-rc.4",
@@ -25323,9 +25323,9 @@
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
     },
     "xmldom": {
-      "version": "0.1.27",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
-      "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk=",
+      "version": "0.1.31",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.31.tgz",
+      "integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ==",
       "optional": true
     },
     "xregexp": {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "mobx": "^5.5.0",
     "mobx-react": "^5.2.8",
     "mobx-state-tree": "^3.4.0",
-    "organelle": "0.0.12",
+    "organelle": "0.0.13",
     "patternomaly": "^1.3.2",
     "populations-react": "0.0.3",
     "populations.js": "^0.1.13",

--- a/src/components/spaces/organisms/cell-models/receptor.json
+++ b/src/components/spaces/organisms/cell-models/receptor.json
@@ -14,5 +14,5 @@
     "organelles/g-protein-body.yml",
     "organelles/g-protein-part.yml"
   ],
-  "hotStart": 500
+  "hotStart": 300
 }

--- a/src/components/spaces/organisms/organelle-wrapper.tsx
+++ b/src/components/spaces/organisms/organelle-wrapper.tsx
@@ -356,20 +356,16 @@ export class OrganelleWrapper extends BaseComponent<OrganelleWrapperProps, Organ
     model.on("view.loaded", () => {
       this.updateReceptorImage();
       this.props.onModelLoaded && this.props.onModelLoaded();
-    });
 
-    if (this.props.zoomLevel === "receptor") {
-      model.setTimeout(
-        () => {
-          for (let i = 0; i < 3; i++) {
-            // The world could have been unmounted since the timeout was set
-            if (model && model.world) {
-              model.world.createAgent(model.world.species.gProtein);
-            }
+      if (this.props.zoomLevel === "receptor") {
+        for (let i = 0; i < 3; i++) {
+          // The world could have been unmounted since the timeout was set
+          if (model && model.world) {
+            model.world.createAgent(model.world.species.gProtein);
           }
-        },
-        1300);
-    }
+        }
+      }
+    });
 
     model.on("hexagon.notify", () => this.updateReceptorImage());
 


### PR DESCRIPTION
This addresses an issue where on slow machines, the model can start before the view starts, and consequently before we're ready to listen to messages from the cell model.

The "stuck signal protein" bug is caused by a signal protein binding, sending the message that it has bound, which is supposed to cause the model to trigger the breaking script, but this doesn't happen because the listener has not been set up.

While it would be good to fix the underlying issue of sending messages before listeners are in place, this simply fixes it by delaying adding the signal proteins until the listeners are ready.