### PR TITLE
Delay moving protein body for a half second

### DIFF
--- a/src/components/spaces/organisms/organelles/g-protein-body.yml
+++ b/src/components/spaces/organisms/organelles/g-protein-body.yml
@@ -7,13 +7,28 @@ dieWhenExitingWorld: false
 properties:
   size: 1.7
   speed: 0.7
-  drection: 0
+  direction: 0
   image_selector: gbodypart2
   second_receptor: false
 rules:
   initialization:
+    switch_state: rotate
+  rotate:
+    if:
+      fact: second_receptor
+    then:
+      - change:
+          prop: direction
+          by: 13
+      - switch_state: wait_one_step
+    else:
       switch_state: wait_one_step
   wait_one_step:
+    wait:
+      for: 50
+      finally:
+        switch_state: move_to_path
+  move_to_path:
     if:
       fact: second_receptor
     then:


### PR DESCRIPTION
Also rotate the protein body since it's now hanging around more noticeably.

For some reason, this requires some verbose switching of states, which I haven't been able to work out.

[#172377106]