### PR TITLE
Update population graph legend layout which fixes graph overlay positions

### DIFF
--- a/src/components/charts/line-chart.tsx
+++ b/src/components/charts/line-chart.tsx
@@ -41,6 +41,9 @@ const defaultOptions: ChartOptions = {
   legend: {
     display: true,
     position: "bottom",
+    labels: {
+      boxWidth: 29
+    }
   },
   maintainAspectRatio: false,
   scales: {


### PR DESCRIPTION
This PR adds a small fix to put population graph legend items on the same line by making the legend box smaller.  This provides a more consistent, readable layout of legend items (no more two line items) and as a result causes graph overlays to appear in the correct location on ALL graph tabs.