### PR TITLE
161597217 population inspect

### DIFF
--- a/src/authoring-schema.json
+++ b/src/authoring-schema.json
@@ -135,6 +135,10 @@
           "title": "Include mixed environment",
           "type": "boolean"
         },
+        "showInspectGenotype": {
+          "title": "Show genotype in inspect view",
+          "type": "boolean"
+        },
         "initialPopulation": {
           "title": "Initial mouse population",
           "type": "object",

--- a/src/authoring.d.ts
+++ b/src/authoring.d.ts
@@ -19,6 +19,7 @@ export type InstructionsAsMarkdown = string;
 export type InitialEnvironment = "white" | "neutral" | "brown";
 export type EnableChangeEnvironmentsButton = boolean;
 export type IncludeMixedEnvironment = boolean;
+export type ShowGenotypeInInspectView = boolean;
 export type White = number;
 export type Tan = number;
 export type NumberOfHawks = number;
@@ -76,6 +77,7 @@ export interface PopulationsModel {
   environment?: InitialEnvironment;
   showSwitchEnvironmentsButton?: EnableChangeEnvironmentsButton;
   includeNeutralEnvironment?: IncludeMixedEnvironment;
+  showInspectGenotype?: ShowGenotypeInInspectView;
   initialPopulation?: InitialMousePopulation;
   numHawks?: NumberOfHawks;
   inheritance?: Inheritance;

--- a/src/components/authoring.tsx
+++ b/src/components/authoring.tsx
@@ -32,6 +32,7 @@ export const defaultAuthoring: ConnectedBioAuthoring = {
     environment: "white",
     showSwitchEnvironmentsButton: true,
     includeNeutralEnvironment: true,
+    showInspectGenotype: true,
     initialPopulation: {
       white: 33.33,
       tan: 33.33

--- a/src/components/inspect-panel.sass
+++ b/src/components/inspect-panel.sass
@@ -1,6 +1,6 @@
-@import "../../vars"
+@import vars
 
-.breeding-inspect
+.inspect-panel
   display: flex
   flex-direction: column
   justify-content: center
@@ -19,13 +19,15 @@
         flex-direction: column
     .inspect-background
       position: absolute
-      top: 41px
+      top: 40px
       left: 23px
       width: 367px
       height: 175px
       border-radius: 100px
       background-color: $color-simdata-brick-light1
       opacity: .75
+      &.population
+        background-color: $color-simdata-amber-light1
       &.gamete
         background-color: $color-nav-shamrock-light1
       &.single
@@ -44,6 +46,9 @@
         font-size: 16px
         font-weight: 500
         margin: 10px
+      .mouse-info
+        &.no-header
+          margin-top: 10px
       .info-row
         display: flex
         flex-direction: row
@@ -56,6 +61,8 @@
           font-size: 14px
           font-weight: 500
           margin-right: 5px
+          &.population
+            color: $color-simdata-amber-dark3
         .info-data
           color: $color-nav-cinder-dark2
           font-size: 14px
@@ -99,6 +106,6 @@
       height: 16px
       margin: 2px
       &.egg
-        background-image: url("../../../assets/icons/egg.svg")
+        background-image: url("../assets/icons/egg.svg")
       &.sperm
-        background-image: url("../../../assets/icons/sperm.svg")
+        background-image: url("../assets/icons/sperm.svg")

--- a/src/components/inspect-panel.tsx
+++ b/src/components/inspect-panel.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
-import { BaseComponent, IBaseProps } from "../../base";
-import { BackpackMouseType } from "../../../models/backpack-mouse";
-import { StackedOrganism } from "../../stacked-organism";
-import { genotypeHTMLLabel, gameteHTMLLabel } from "../../../utilities/genetics";
-import "./breeding-inspect.sass";
+import { BaseComponent, IBaseProps } from "./base";
+import { BackpackMouseType } from "../models/backpack-mouse";
+import { StackedOrganism } from "./stacked-organism";
+import { genotypeHTMLLabel, gameteHTMLLabel } from "../utilities/genetics";
+import "./inspect-panel.sass";
 
 interface IProps extends IBaseProps {
   mouse1?: BackpackMouseType;
@@ -11,15 +11,16 @@ interface IProps extends IBaseProps {
   pairLabel: string;
   isOffspring: boolean;
   isGamete: boolean;
+  isPopulationInspect?: boolean;
 }
 interface IState {}
 
-export class BreedingInspect extends BaseComponent<IProps, IState> {
+export class InspectPanel extends BaseComponent<IProps, IState> {
 
   public render() {
     const { mouse1, mouse2, pairLabel } = this.props;
     return(
-      <div className="breeding-inspect">
+      <div className="inspect-panel">
         {(mouse1 && mouse2) && this.renderInspectedPair(mouse1, mouse2, pairLabel)}
         {(mouse1 && !mouse2) && this.renderInspectedMouse(mouse1)}
       </div>
@@ -41,12 +42,13 @@ export class BreedingInspect extends BaseComponent<IProps, IState> {
 
   private renderInspectedMouse(mouse: BackpackMouseType) {
     const bgClass = "inspect-background single " + (this.props.isGamete ? "gamete " : "")
+                    + (this.props.isPopulationInspect ? "population " : "")
                     + (this.props.isGamete && this.props.isOffspring ? "low" : "");
     return(
       <div className="pair-container single">
         { (this.props.isGamete && this.props.isOffspring) && this.renderGametePanel(mouse) }
         <div className={bgClass} />
-        {this.renderMouse(mouse, !this.props.isOffspring && mouse.sex === "male")}
+        {this.renderMouse(mouse, !this.props.isPopulationInspect && !this.props.isOffspring && mouse.sex === "male")}
       </div>
     );
   }
@@ -64,9 +66,11 @@ export class BreedingInspect extends BaseComponent<IProps, IState> {
           showHetero={true}
           flipped={flip}
         />
-        <div className="mouse-label">
-          {this.props.isOffspring ? "Offspring" : (mouse.sex === "female" ? "Mother" : "Father")}
-        </div>
+        { !this.props.isPopulationInspect &&
+          <div className="mouse-label">
+            {this.props.isOffspring ? "Offspring" : (mouse.sex === "female" ? "Mother" : "Father")}
+          </div>
+        }
         {this.renderMouseInfo(mouse)}
       </div>
     );
@@ -78,24 +82,26 @@ export class BreedingInspect extends BaseComponent<IProps, IState> {
                        mouse.baseColor === "tan" ? "Medium brown" : "Dark brown";
     const genotypeLabel = genotypeHTMLLabel(mouse.genotype);
     const rowClass = "info-row" + (this.props.mouse2 ? "" : " wide");
+    const mouseInfoClass = "mouse-info" + (this.props.isPopulationInspect ? " no-header" : "");
+    const infoTypeClass = "info-type" + (this.props.isPopulationInspect ? " population " : "");
     return (
-      <div className="mouse-info">
+      <div className={mouseInfoClass}>
         <div className={rowClass}>
-          <div className="info-type">
+          <div className={infoTypeClass}>
             {"Fur Color: "}
             <span className="info-data">{colorLabel}</span>
           </div>
         </div>
         { (!this.props.isGamete || this.props.isOffspring) &&
           <div className={rowClass}>
-            <div className="info-type">
+            <div className={infoTypeClass}>
               {"Sex: "}
               <span className="info-data">{sexLabel}</span>
             </div>
           </div>
         }
         <div className={rowClass}>
-          <div className="info-type">
+          <div className={infoTypeClass}>
             {"Genotype: "}
             <span className="info-data"
                dangerouslySetInnerHTML={{ __html: genotypeLabel }}
@@ -104,7 +110,7 @@ export class BreedingInspect extends BaseComponent<IProps, IState> {
         </div>
         { (this.props.isGamete && !this.props.isOffspring) &&
           <div className={rowClass}>
-            <div className="info-type">
+            <div className={infoTypeClass}>
               {"Gametes: "}
               <span className="info-data"
                dangerouslySetInnerHTML={{ __html: this.getGameteLabel(mouse) }}
@@ -114,7 +120,7 @@ export class BreedingInspect extends BaseComponent<IProps, IState> {
         }
         { (this.props.isGamete && !this.props.isOffspring) &&
           <div className={rowClass}>
-            <div className="info-type">
+            <div className={infoTypeClass}>
               {"Gametes given to offspring: "}
               <span className="info-data">{this.getGameteOffspringLabel(mouse)}</span>
             </div>

--- a/src/components/inspect-panel.tsx
+++ b/src/components/inspect-panel.tsx
@@ -12,6 +12,7 @@ interface IProps extends IBaseProps {
   isOffspring: boolean;
   isGamete: boolean;
   isPopulationInspect?: boolean;
+  showGenotype: boolean;
 }
 interface IState {}
 
@@ -100,14 +101,16 @@ export class InspectPanel extends BaseComponent<IProps, IState> {
             </div>
           </div>
         }
-        <div className={rowClass}>
-          <div className={infoTypeClass}>
-            {"Genotype: "}
-            <span className="info-data"
-               dangerouslySetInnerHTML={{ __html: genotypeLabel }}
-            />
+        { this.props.showGenotype &&
+          <div className={rowClass}>
+            <div className={infoTypeClass}>
+              {"Genotype: "}
+              <span className="info-data"
+                dangerouslySetInnerHTML={{ __html: genotypeLabel }}
+              />
+            </div>
           </div>
-        </div>
+        }
         { (this.props.isGamete && !this.props.isOffspring) &&
           <div className={rowClass}>
             <div className={infoTypeClass}>

--- a/src/components/spaces/breeding-space.tsx
+++ b/src/components/spaces/breeding-space.tsx
@@ -43,6 +43,7 @@ export class BreedingSpaceComponent extends BaseComponent<IProps, IState> {
                   pairLabel={content.label}
                   isOffspring={content.isOffspring}
                   isGamete={content.isGamete}
+                  showGenotype={true}
                  />;
         default:
           return null;

--- a/src/components/spaces/breeding-space.tsx
+++ b/src/components/spaces/breeding-space.tsx
@@ -6,7 +6,7 @@ import { InstructionsComponent } from "../instructions";
 import { RightPanelType } from "../../models/ui";
 import { BreedingContainer } from "./breeding/breeding-container";
 import { BreedingData } from "./breeding/breeding-data";
-import { BreedingInspect } from "./breeding/breeding-inspect";
+import { InspectPanel } from "../inspect-panel";
 
 interface InspectContent {
   title: string;
@@ -37,7 +37,7 @@ export class BreedingSpaceComponent extends BaseComponent<IProps, IState> {
         case "information":
           const content: InspectContent = this.getInspectedContent();
           rightPanelTitle = content.title;
-          return <BreedingInspect
+          return <InspectPanel
                   mouse1={content.mouse1}
                   mouse2={content.mouse2}
                   pairLabel={content.label}

--- a/src/components/spaces/breeding/nest-pair.sass
+++ b/src/components/spaces/breeding/nest-pair.sass
@@ -53,24 +53,24 @@
     border-radius: 40px
     transition-duration: .25s
     &.left-top
-      left: 16px
-      top: -6px
+      left: 7px
+      top: -1px
       transform: rotate(0deg)
     &.left-middle
-      left: 50px
-      top: 2px
-      transform: rotate(8deg)
+      left: 49px
+      top: 3px
+      transform: rotate(6deg)
     &.left-bottom
-      left: 18px
-      top: 2px
-      transform: rotate(8deg)
+      left: 13px
+      top: 1px
+      transform: rotate(12deg)
     &.right-top
-      left: 14px
-      top: 0px
-      transform: rotate(-8deg)
-    &.right-middle
       left: 16px
-      top: 6px
+      top: -1px
+      transform: rotate(-10deg)
+    &.right-middle
+      left: 21px
+      top: 8px
       transform: rotate(-8deg)
     &.right-bottom
       left: 20px

--- a/src/components/spaces/populations-space.tsx
+++ b/src/components/spaces/populations-space.tsx
@@ -37,6 +37,7 @@ export class PopulationsSpaceComponent extends BaseComponent<IProps, IState> {
                   isGamete={false}
                   isOffspring={false}
                   isPopulationInspect={true}
+                  showGenotype={populations.model.showInspectGenotype}
                  />;
         default:
           return null;

--- a/src/components/spaces/populations-space.tsx
+++ b/src/components/spaces/populations-space.tsx
@@ -6,6 +6,7 @@ import { PopulationsComponent } from "./populations/populations-container";
 import { InstructionsComponent } from "../instructions";
 import { Chart } from "../charts/chart";
 import { RightPanelType } from "../../models/ui";
+import { InspectPanel } from "../inspect-panel";
 
 interface IProps extends IBaseProps {}
 interface IState {}
@@ -17,21 +18,40 @@ export class PopulationsSpaceComponent extends BaseComponent<IProps, IState> {
   public render() {
     const { populations } = this.stores;
     const rightPanelType = populations.rightPanel;
-    const graphPanel = <Chart title="Population"
-                          chartData={populations.currentData}
-                          chartType={"line"}
-                          isPlaying={populations.isPlaying} />;
-    const instructionsPanel = <InstructionsComponent content={populations.instructions}/>;
-    const rightPanelContent = rightPanelType === "data" ? graphPanel : instructionsPanel;
+    let rightPanelTitle = "";
+    const rightPanelContent = (() => {
+      switch (rightPanelType) {
+        case "instructions":
+          return <InstructionsComponent content={populations.instructions}/>;
+        case "data":
+          return <Chart title="Population"
+                  chartData={populations.currentData}
+                  chartType={"line"}
+                  isPlaying={populations.isPlaying}
+                 />;
+        case "information":
+          rightPanelTitle = "Inspect: Mouse";
+          return <InspectPanel
+                  mouse1={populations.model.inspectedMouse}
+                  pairLabel={""}
+                  isGamete={false}
+                  isOffspring={false}
+                  isPopulationInspect={true}
+                 />;
+        default:
+          return null;
+      }
+    })();
 
     return (
       <TwoUpDisplayComponent
         leftTitle="Explore: Population"
         leftPanel={<PopulationsComponent />}
+        rightTitle={rightPanelTitle}
         rightPanel={rightPanelContent}
         instructionsIconEnabled={true}
         dataIconEnabled={true}
-        informationIconEnabled={false}
+        informationIconEnabled={true}
         selectedRightPanel={rightPanelType}
         onClickRightIcon={this.setRightPanel}
         spaceClass="populations"

--- a/src/components/spaces/populations/populations-container.tsx
+++ b/src/components/spaces/populations/populations-container.tsx
@@ -198,6 +198,14 @@ export class PopulationsComponent extends BaseComponent<IProps, IState> {
           if (added){
             this.stores.populations.removeAgent(selectedMouse);
           }
+        } else if (evt.type === "click" && populations.interactionMode === "inspect") {
+          const selectedMouse = evt.agents.mice;
+          const mouse = BackpackMouse.create({
+            sex: selectedMouse.get("sex"),
+            genotype: (selectedMouse as any)._genomeButtonsString()
+          });
+          populations.model.setInspectedMouse(mouse);
+          populations.setRightPanel("information");
         } else if (evt.type === "mousemove" && populations.interactionMode !== "none") {
           if (currentHighlightMouse) {
             currentHighlightMouse.set("hover", "");

--- a/src/components/stacked-organism.sass
+++ b/src/components/stacked-organism.sass
@@ -2,6 +2,9 @@
 
 .stacked-organism
   position: relative
+  display: flex
+  justify-content: center
+  align-items: center
 
   &:hover .selection-stack.show
     opacity: 1
@@ -26,20 +29,25 @@
       transform: translate3d(0px, 0px, 0px) translateY(-50%) translateX(-50%) scaleX(-1)
   .hetero-stack
     position: absolute
-    top: 0
-    left: 0
+    border-color: $left-nav-legend-heterozygote-color
+    border-style: dotted
+    border-radius: 50%
     opacity: 0
     transition-duration: .25s
     &.show
       opacity: 1
   .sex-stack
     position: absolute
-    top: 0
-    left: 0
+    border-style: solid
+    border-radius: 50%
     opacity: 0
     transition-duration: .25s
     &.show
       opacity: 1
+    &.male
+      border-color: $left-nav-legend-male-color
+    &.female
+      border-color: $left-nav-legend-female-color
   .gamete-view-stack
     position: absolute
     top: 0

--- a/src/components/stacked-organism.tsx
+++ b/src/components/stacked-organism.tsx
@@ -18,9 +18,6 @@ interface IProps {
 }
 
 const path = "assets/curriculum/mouse/populations/";
-const femaleSexImage =  path + "female-stack.png";
-const maleSexImage =    path + "male-stack.png";
-const heteroImage =     path + "heterozygous-stack.png";
 const selectionImage =  path + "select-stack.png";
 
 export const StackedOrganism: React.SFC<IProps> = (props) => {
@@ -28,8 +25,7 @@ export const StackedOrganism: React.SFC<IProps> = (props) => {
   const gameteViewClass = "gamete-view-stack " + (props.showGameteSelection ? "show" : "");
   const inspectClass = "inspect-stack";
   const heteroClass = "hetero-stack " + ((props.showHetero && props.organism.isHeterozygote) ? "show" : "");
-  const sexImage = props.organism.sex === "female" ? femaleSexImage : maleSexImage;
-  const sexClass = "sex-stack " + (props.showSex ? "show" : "");
+  const sexClass = "sex-stack " + props.organism.sex + (props.showSex ? " show" : "");
   const imgClasses = "organism-image " + (props.flipped ? "flip" : "");
   const label = genotypeHTMLLabel(props.organism.genotype);
   const labelClass = "genotype-label " + (props.isOffspring ? "child-mouse" : "parent-mouse");
@@ -40,6 +36,18 @@ export const StackedOrganism: React.SFC<IProps> = (props) => {
   };
   const innerSize = {
     height: props.height * 0.45,
+  };
+  const normalHeight = 150;
+  const normalBorderWidth = 4;
+  const sexSize = {
+    height: props.height * .9,
+    width: props.height * .9,
+    borderWidth: (normalBorderWidth * props.height / normalHeight)
+  };
+  const heteroSize = {
+    height: props.height * .78,
+    width: props.height * .78,
+    borderWidth: (normalBorderWidth * props.height / normalHeight)
   };
 
   return (
@@ -54,8 +62,8 @@ export const StackedOrganism: React.SFC<IProps> = (props) => {
             key={`org-image-${i}`} data-test={`org-image-${i}`} />
         )
       }
-      <img src={heteroImage} className={heteroClass} style={fullSize} data-test="hetero-image" />
-      <img src={sexImage} className={sexClass} style={fullSize} data-test="sex-image" />
+      <div className={sexClass} style={sexSize}/>
+      <div className={heteroClass} style={heteroSize}/>
     </div>
   );
 

--- a/src/models/spaces/populations/mouse-model/mouse-populations-model.ts
+++ b/src/models/spaces/populations/mouse-model/mouse-populations-model.ts
@@ -4,6 +4,7 @@ import { Events, Environment } from "populations.js";
 import { ToolbarButton } from "../populations";
 import { ChartDataModel } from "../../charts/chart-data";
 import { ChartAnnotationModel, ChartAnnotationType } from "../../charts/chart-annotation";
+import { BackpackMouse, BackpackMouseType } from "../../../backpack-mouse";
 
 const dataColors = {
   white: {
@@ -190,7 +191,8 @@ export const MousePopulationsModel = types
     "enableGenotypeChart": true,
     "enableAllelesChart": true,
     "deadMice.chanceOfShowingBody": types.number,
-    "deadMice.timeToShowBody": types.number
+    "deadMice.timeToShowBody": types.number,
+    "inspectedMouse": types.maybe(BackpackMouse)
   })
   .volatile(self => ({
     hawksAdded: false,
@@ -350,6 +352,9 @@ export const MousePopulationsModel = types
         }
       },
       actions: {
+        setInspectedMouse(mouse: BackpackMouseType) {
+          self.inspectedMouse = mouse;
+        },
         setEnvironmentColor(color: EnvironmentColorType) {
           self.environment = color;
           if (interactive) {

--- a/src/models/spaces/populations/mouse-model/mouse-populations-model.ts
+++ b/src/models/spaces/populations/mouse-model/mouse-populations-model.ts
@@ -176,6 +176,7 @@ export const MousePopulationsModel = types
     "initialPopulation.tan": types.number,
     "showSwitchEnvironmentsButton": types.boolean,
     "includeNeutralEnvironment": types.boolean,
+    "showInspectGenotype": types.boolean,
     "inheritance.showStudentControlOfMutations": types.boolean,
     "inheritance.breedWithMutations": types.boolean,
     "inheritance.chanceOfMutations": types.number,

--- a/src/models/spaces/populations/populations.ts
+++ b/src/models/spaces/populations/populations.ts
@@ -141,14 +141,6 @@ export const PopulationsModel = types
             }
             self.interactionMode = mode;
           }
-
-          // set "info" mode on interactive. This is temporary, eventually we will show info in right
-          // panel using the same mouse handler as the select view.
-          if (self.interactionMode === "inspect") {
-            self.model.interactive.enterInspectMode();
-          } else {
-            self.model.interactive.exitInspectMode();
-          }
         }
       }
     };


### PR DESCRIPTION
This PR adds the population level mouse inspect, the ability to author the visibility of the population inspect genotype label, and some small UI fixes.  Changes include:
- inspecting a mouse in the population level now shows the mouse information in the right panel.  Because of overlap, the breeding and population inspect have been collapsed into a single React component,
- population inspect genotype label can be shown or hidden using the authoring tools
- updates to the stacked organism male/female/hetero selection circles to use CSS so they would be more in line with the UI spec (request from Michael when he reviewed my work - he wanted the circles to be thinner in the inspect views).  I did NOT update the raw PNG images since these are also used in the population model.  Updating the images to make the circles smaller makes them hard to read in the population model.  The most flexible approach was to use CSS in the stacked organism component and size the circles using CSS as needed.
- small changes to the breeding nest highlight positions (while working on the inspect, it became apparent that their positions, in some cases, were off).