### PR TITLE
Layout fixes on mobile

### DIFF
--- a/src/components/inspect-panel.sass
+++ b/src/components/inspect-panel.sass
@@ -79,6 +79,7 @@
     justify-content: center
     align-items: center
     margin-bottom: 40px
+    height: 74px
     .gamete-panel-container
       display: flex
       flex-direction: column

--- a/src/components/spaces/breeding/breeding-view.sass
+++ b/src/components/spaces/breeding/breeding-view.sass
@@ -166,12 +166,14 @@
       left: 5px
       font-size: 10px
       font-weight: 400
+      line-height: 10px
     .alleles-message
       color: $color-nav-cinder-dark2
       top: 50px
       left: 5px
       font-size: 10px
       font-weight: 400
+      line-height: 10px
     .reset-button-container
       top: 190px
       left: 5px


### PR DESCRIPTION
This PR fixes two small layout issues on iPad by enforcing stricter CSS layout rules:
- when inspecting gametes in the heredity level, the inspected mouse had an incorrect layout position in the right panel
- text for the total number of offspring was hidden behind reset button