### PR TITLE
Save population state when user switches spaces

### DIFF
--- a/src/components/spaces/populations/populations-container.tsx
+++ b/src/components/spaces/populations/populations-container.tsx
@@ -17,6 +17,7 @@ interface IState {
 }
 
 let currentHighlightMouse: Agent | undefined;
+let firstMount = true;
 
 @inject("stores")
 @observer
@@ -27,7 +28,13 @@ export class PopulationsComponent extends BaseComponent<IProps, IState> {
   }
 
   public componentDidMount() {
-    setTimeout(this.stores.populations.setupGraph, 1000);
+    if (firstMount) {
+      // only initialize the populations graph on the very first mount.
+      // from then on, the graph will only be re-initialized when the user
+      // explicitly resets the model
+      setTimeout(this.stores.populations.initializeGraph, 1000);
+    }
+    firstMount = false;
   }
 
   public componentWillUnmount() {

--- a/src/models/spaces/populations/mouse-model/hawks-mice-interactive.ts
+++ b/src/models/spaces/populations/mouse-model/hawks-mice-interactive.ts
@@ -392,7 +392,7 @@ export function createInteractive(model: MousePopulationsModelType) {
   interactive.loadEnvironment = (state: EnvironmentState) => {
     env = createEnvironment(environmentColor, mouseSpecies);
     interactive.environment = env;
-    interactive.environment.agents = state.agents;
+    state.agents.forEach(agent => env.addAgent(agent));
     interactive.environment.date = state.date;
   };
 

--- a/src/models/spaces/populations/mouse-model/mouse-populations-model.ts
+++ b/src/models/spaces/populations/mouse-model/mouse-populations-model.ts
@@ -258,14 +258,14 @@ export const MousePopulationsModel = types
     }
 
     function getModelDate() {
-      if (interactive) {
+      if (interactive && interactive.environment) {
         return interactive.environment.date / 10;
       }
       return 0;
     }
 
     Events.addEventListener(Environment.EVENTS.STEP, () => {
-      if (interactive) {
+      if (interactive && interactive.environment) {
         const date = interactive.environment.date;
         // add data every 5th step
         if (date % 5 === 0) {
@@ -364,7 +364,7 @@ export const MousePopulationsModel = types
         },
         setEnvironmentColor(color: EnvironmentColorType) {
           self.environment = color;
-          if (interactive) {
+          if (interactive && interactive.environment) {
             addEnvironmentAnnotation(interactive.environment.date, color);
           }
         },

--- a/src/models/spaces/populations/mouse-model/mouse-populations-model.ts
+++ b/src/models/spaces/populations/mouse-model/mouse-populations-model.ts
@@ -1,5 +1,5 @@
 import { types, Instance } from "mobx-state-tree";
-import { createInteractive, HawksMiceInteractive } from "./hawks-mice-interactive";
+import { createInteractive, HawksMiceInteractive, EnvironmentState } from "./hawks-mice-interactive";
 import { Events, Environment } from "populations.js";
 import { ToolbarButton } from "../populations";
 import { ChartDataModel } from "../../charts/chart-data";
@@ -168,6 +168,8 @@ export const EnvironmentColorNames = {
   brown: "Field"
 };
 
+let savedEnvironmentState: EnvironmentState | null = null;
+
 export const MousePopulationsModel = types
   .model("MousePopulations", {
     "environment": EnvironmentColorTypeEnum,
@@ -326,6 +328,10 @@ export const MousePopulationsModel = types
       views: {
         get interactive(): HawksMiceInteractive {
           if (interactive) {
+            if (savedEnvironmentState) {
+              interactive.loadEnvironment(savedEnvironmentState);
+              savedEnvironmentState = null;
+            }
             return interactive;
           } else {
             interactive = createInteractive(self as MousePopulationsModelType);
@@ -396,9 +402,10 @@ export const MousePopulationsModel = types
         setHawksAdded(val: boolean) {
           self.hawksAdded = val;
         },
-        destroyInteractive() {
-          interactive = undefined;
-          setupGraph();
+        saveInteractive() {
+          if (interactive) {
+            savedEnvironmentState = interactive.saveAndDestroyEnvironment();
+          }
         },
         setupGraph,
         addSettingsAnnotation,

--- a/src/models/spaces/populations/mouse-model/mouse-populations-model.ts
+++ b/src/models/spaces/populations/mouse-model/mouse-populations-model.ts
@@ -313,16 +313,16 @@ export const MousePopulationsModel = types
       lastSettingsAnnotationDate = timeSinceLastAnnotation > 30 ? now : now - 100;
     }
 
-    function setupGraph() {
+    function initializeGraph() {
       self.chartData.dataSets.forEach(d => d.clearDataPoints());
       self.chartData.clearAnnotations();
       addEnvironmentAnnotation(0, self.environment);
-      if (interactive) {
+      if (interactive && interactive.environment) {
         addData(getModelDate(), interactive.getData());
       }
     }
 
-    setupGraph();
+    initializeGraph();
 
     return {
       views: {
@@ -379,7 +379,7 @@ export const MousePopulationsModel = types
             interactive.reset();
           }
           this.setHawksAdded(false);
-          setupGraph();
+          initializeGraph();
         },
         toggleShowMaxPoints() {
           self.showMaxPoints = !self.showMaxPoints;
@@ -407,7 +407,7 @@ export const MousePopulationsModel = types
             savedEnvironmentState = interactive.saveAndDestroyEnvironment();
           }
         },
-        setupGraph,
+        initializeGraph,
         addSettingsAnnotation,
       }
     };

--- a/src/models/spaces/populations/populations.ts
+++ b/src/models/spaces/populations/populations.ts
@@ -2,7 +2,6 @@ import { types, Instance, detach } from "mobx-state-tree";
 import { MousePopulationsModel, MousePopulationsModelType } from "./mouse-model/mouse-populations-model";
 import { Interactive, Events, Environment, Agent } from "populations.js";
 import { ChartDataModelType } from "../charts/chart-data";
-import { type } from "os";
 import { RightPanelTypeEnum, RightPanelType } from "../../ui";
 import { Unit } from "../../../authoring";
 
@@ -112,7 +111,7 @@ export const PopulationsModel = types
         },
         close() {
           self.model.interactive.stop();
-          self.model.destroyInteractive();
+          self.model.saveInteractive();
         },
         setupGraph() {
           self.model.setupGraph();

--- a/src/models/spaces/populations/populations.ts
+++ b/src/models/spaces/populations/populations.ts
@@ -113,8 +113,8 @@ export const PopulationsModel = types
           self.model.interactive.stop();
           self.model.saveInteractive();
         },
-        setupGraph() {
-          self.model.setupGraph();
+        initializeGraph() {
+          self.model.initializeGraph();
         }
       }
     };


### PR DESCRIPTION
If a user leaves the population model and then comes back to it, the model and graph should remain as they were before.

Note: There is a pre-existing issue where the model will turn black after it is opened too many times. This was made more noticeable in testing this feature, as testing it involved flipping back and forth a lot, but it seems to be the same on master. This branch does not attempt to fix that bug.