### PR TITLE
172444650 graph label touch

### DIFF
--- a/src/models/spaces/charts/chart-annotation.ts
+++ b/src/models/spaces/charts/chart-annotation.ts
@@ -24,6 +24,7 @@ export const ChartAnnotationModel = types
     label: types.maybe(types.string),
     labelColor: types.optional(types.string, "white"),
     labelBackgroundColor: types.optional(types.string, "rgba(0,0,0,0.8)"),
+    labelHighlightColor: types.optional(types.string, "rgba(0,0,0,0.8)"),
     labelXOffset: types.optional(types.number, 0),
     labelYOffset: types.optional(types.number, 0),
     // if present, will add mouse rollover and click handlers
@@ -37,11 +38,15 @@ export const ChartAnnotationModel = types
     yMin: types.maybe(types.number)
   })
   .volatile(self => ({
-    showingExpandLabel: false
+    showingExpandLabel: false,
+    showingHighlight: false
   }))
   .actions(self => ({
     setShowingExpandLabel: (val: boolean) => {
       self.showingExpandLabel = val;
+    },
+    setHighlight: (val: boolean) => {
+      self.showingHighlight = val;
     }
   }))
   .views(self => ({
@@ -97,7 +102,7 @@ export const ChartAnnotationModel = types
           xAdjust,
           yAdjust: 305 - self.labelYOffset,
           fontColor: self.labelColor,
-          backgroundColor: self.labelBackgroundColor
+          backgroundColor: self.showingHighlight ? self.labelHighlightColor : self.labelBackgroundColor,
         };
       }
 
@@ -110,6 +115,8 @@ export const ChartAnnotationModel = types
           self.setShowingExpandLabel(val);
           this.chartInstance.update();
         };
+        formatted.onMouseenter = () => self.setHighlight(true);
+        formatted.onMouseleave = () => self.setHighlight(false);
         formatted.onClick = () => self.setShowingExpandLabel(!self.showingExpandLabel);
       }
 

--- a/src/models/spaces/charts/chart-annotation.ts
+++ b/src/models/spaces/charts/chart-annotation.ts
@@ -44,6 +44,7 @@ export const ChartAnnotationModel = types
   .actions(self => ({
     setShowingExpandLabel: (val: boolean) => {
       self.showingExpandLabel = val;
+      self.showingHighlight = val ? self.showingHighlight : false;
     },
     setHighlight: (val: boolean) => {
       self.showingHighlight = val;

--- a/src/models/spaces/charts/chart-annotation.ts
+++ b/src/models/spaces/charts/chart-annotation.ts
@@ -110,8 +110,6 @@ export const ChartAnnotationModel = types
           self.setShowingExpandLabel(val);
           this.chartInstance.update();
         };
-        formatted.onMouseenter = () => self.setShowingExpandLabel(true);
-        formatted.onMouseleave = () => self.setShowingExpandLabel(false);
         formatted.onClick = () => self.setShowingExpandLabel(!self.showingExpandLabel);
       }
 

--- a/src/models/spaces/populations/mouse-model/mouse-populations-model.ts
+++ b/src/models/spaces/populations/mouse-model/mouse-populations-model.ts
@@ -9,15 +9,18 @@ import { BackpackMouse, BackpackMouseType } from "../../../backpack-mouse";
 const dataColors = {
   white: {
     mice: "#f4ce83",
-    environment: "rgb(251,235,205)"
+    environment: "rgb(251,235,205)",
+    environmentHighlight: "rgba(251,235,205,.7)"
   },
   neutral: {
     mice: "#db9e26",
-    environment: "rgb(241,216,168)"
+    environment: "rgb(241,216,168)",
+    environmentHighlight: "rgba(241,216,168, .7)"
   },
   brown: {
     mice: "#795423",
-    environment: "rgb(201,187,167)"
+    environment: "rgb(201,187,167)",
+    environmentHighlight: "rgba(201,187,167,.7)"
   }
 };
 
@@ -290,7 +293,8 @@ export const MousePopulationsModel = types
         labelXOffset: -15,
         expandOffset: -27,
         labelColor: "black",
-        labelBackgroundColor: dataColors[color].environment
+        labelBackgroundColor: dataColors[color].environment,
+        labelHighlightColor: dataColors[color].environmentHighlight
       });
       self.chartData.addAnnotation(colorAnnotation);
       lastEnvironmentColorAnnotationDate = date;


### PR DESCRIPTION
This PR makes changes to the population level graph annotation labels so they they work better with touch screens and have a more uniform approach to being shown and hidden.  Changes include:
- show/hide annotation label on click/touch
- when using mouse, adjust color on hover