### PR TITLE
add meta tag to define viewport constraints

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <title>Connected Bio</title>
     <meta name="description" content="Connected Bio Spaces">
+    <meta name="viewport" content="initial-scale=1,user-scalable=no,maximum-scale=1">
     <link rel="shortcut icon" href="favicon.ico">
     <link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css?family=Ubuntu:400,500,700&display=swap" rel="stylesheet">


### PR DESCRIPTION
This PR adds viewport constraints via a meta tag which enable fullscreen to work in both portrait and landscape mode on mobile.  Previously entering fullscreen in some modes (such as portrait) on mobile would cause conflict between our scaling code and the screenfull fullscreen mode (we were getting conflicting screen widths).  