### PR TITLE
Add mutations to heredity level breeding

### DIFF
--- a/src/authoring-schema.json
+++ b/src/authoring-schema.json
@@ -264,6 +264,18 @@
           "title": "Instructions (as markdown)",
           "type": "string"
         },
+        "enableStudentControlOfMutations": {
+          "title": "Enable student mutation control",
+          "type": "boolean"
+        },
+        "breedWithMutations": {
+          "title": "Breed with mutations",
+          "type": "boolean"
+        },
+        "chanceOfMutations": {
+          "title": "Chance of mutations (%)",
+          "type": "number"
+        },
         "enableInspectGametes": {
           "title": "Enable inspect gametes button",
           "type": "boolean"

--- a/src/authoring.d.ts
+++ b/src/authoring.d.ts
@@ -42,6 +42,9 @@ export type ShowMysterySubstanceLabels = boolean;
 export type AllowZoomingToReceptor = boolean;
 export type AllowZoomingToNucleus = boolean;
 export type InstructionsAsMarkdown2 = string;
+export type EnableStudentMutationControl1 = boolean;
+export type BreedWithMutations1 = boolean;
+export type ChanceOfMutations1 = number;
 export type EnableInspectGametesButton = boolean;
 export type EnableMouseFurColorPieChart = boolean;
 export type EnableMouseGenotypesPieChart = boolean;
@@ -123,6 +126,9 @@ export interface OrganismModel {
 }
 export interface BreedingModel {
   instructions?: InstructionsAsMarkdown2;
+  enableStudentControlOfMutations?: EnableStudentMutationControl1;
+  breedWithMutations?: BreedWithMutations1;
+  chanceOfMutations?: ChanceOfMutations1;
   enableInspectGametes?: EnableInspectGametesButton;
   enableColorChart?: EnableMouseFurColorPieChart;
   enableGenotypeChart?: EnableMouseGenotypesPieChart;

--- a/src/components/authoring.tsx
+++ b/src/components/authoring.tsx
@@ -67,6 +67,9 @@ export const defaultAuthoring: ConnectedBioAuthoring = {
   },
   breeding: {
     instructions: "",
+    enableStudentControlOfMutations: false,
+    breedWithMutations: false,
+    chanceOfMutations: 2,
     enableInspectGametes: true,
     enableColorChart: true,
     enableGenotypeChart: true,

--- a/src/models/spaces/breeding/breeding.ts
+++ b/src/models/spaces/breeding/breeding.ts
@@ -130,11 +130,11 @@ export const NestPair = types.model({
       self.hasBeenVisited = true;     // can't be set false
     }
   },
-  breedLitter(litterSize: number) {
+  breedLitter(litterSize: number, chanceOfMutations: number) {
     const litter: BackpackMouseType[] = [];
     const positions: number[] = [];
     for (let i = 0; i < litterSize; i++) {
-      const child = breed(self.mother, self.father);
+      const child = breed(self.mother, self.father, chanceOfMutations);
       litter.push(BackpackMouse.create(child));
       positions.push(i);
     }
@@ -257,6 +257,9 @@ export const BreedingModel = types
     instructions: "",
     showSexStack: false,
     showHeteroStack: false,
+    breedWithMutations: false,
+    enableStudentControlOfMutations: false,
+    chanceOfMutations: types.number,
     interactionMode: types.optional(BreedingInteractionModeEnum, "breed"),
     backgroundType: types.optional(EnvironmentColorTypeEnum, "neutral"),
     nestPairs: types.array(NestPair),
@@ -282,7 +285,7 @@ export const BreedingModel = types
       const nestPair = self.nestPairs.find(pair => pair.id === self.breedingNestPairId);
       if (!nestPair) return;
       const litterSize = self.minLitterSize + Math.floor(Math.random() * (self.maxLitterSize - self.minLitterSize + 1));
-      nestPair.breedLitter(litterSize);
+      nestPair.breedLitter(litterSize, self.breedWithMutations ? self.chanceOfMutations / 100 : 0);
       self.rightPanel = "data";
     },
 
@@ -305,6 +308,10 @@ export const BreedingModel = types
 
     setShowHeteroStack(show: boolean) {
       self.showHeteroStack = show;
+    },
+
+    setBreedWithMutations(value: boolean) {
+      self.breedWithMutations = value;
     },
 
     toggleInteractionMode(mode: "select" | "inspect" | "breed" | "gametes") {
@@ -402,6 +409,16 @@ export const BreedingModel = types
           action: (val: boolean) => {
             self.setShowHeteroStack(val);
           }
+        });
+
+        buttons.push({
+          title: "Mutations",
+          type: "checkbox",
+          value: self.breedWithMutations,
+          action: (val: boolean) => {
+            self.setBreedWithMutations(val);
+          },
+          enabled: self.enableStudentControlOfMutations
         });
         return buttons;
       },

--- a/src/utilities/genetics.ts
+++ b/src/utilities/genetics.ts
@@ -11,9 +11,12 @@ export interface Gamete {
   sexChromosome: "X" | "Y";
 }
 
-export function createGamete(org: Organism): Gamete {
+export function createGamete(org: Organism, chanceOfMutations: number): Gamete {
   const alleles = org.genotype.split("");
-  const allele = alleles[Math.round(Math.random())] as "R" | "C";
+  const orgAllele = alleles[Math.round(Math.random())] as "R" | "C";
+  const allele = (Math.random() < chanceOfMutations)
+                      ? orgAllele === "R" ? "C" : "R"
+                      : orgAllele;
   const sexChromosome = org.sex === "female"
     ? "X"
     : Math.random() < 0.5 ? "X" : "Y";
@@ -23,14 +26,8 @@ export function createGamete(org: Organism): Gamete {
   };
 }
 
-export function fertilize(motherGamete: Gamete, fatherGamete: Gamete, chanceOfMutations: number): Organism {
-  const mAllele = (Math.random() < chanceOfMutations)
-                  ? motherGamete.allele === "R" ? "C" : "R"
-                  : motherGamete.allele;
-  const fAllele = (Math.random() < chanceOfMutations)
-                  ? fatherGamete.allele === "R" ? "C" : "R"
-                  : fatherGamete.allele;
-  const genotype = `${mAllele}${fAllele}` as "RR" | "RC" | "CR" | "CC";
+export function fertilize(motherGamete: Gamete, fatherGamete: Gamete): Organism {
+  const genotype = `${motherGamete.allele}${fatherGamete.allele}` as "RR" | "RC" | "CR" | "CC";
   const sex = fatherGamete.sexChromosome === "X" ? "female" : "male";
 
   return {
@@ -40,10 +37,10 @@ export function fertilize(motherGamete: Gamete, fatherGamete: Gamete, chanceOfMu
 }
 
 export function breed(mother: Organism, father: Organism, chanceOfMutations: number): Organism {
-  const motherGamete = createGamete(mother);
-  const fatherGamete = createGamete(father);
+  const motherGamete = createGamete(mother, chanceOfMutations);
+  const fatherGamete = createGamete(father, chanceOfMutations);
 
-  return fertilize(motherGamete, fatherGamete, chanceOfMutations);
+  return fertilize(motherGamete, fatherGamete);
 }
 
 export function genotypeHTMLLabel(genotype: string): string {

--- a/src/utilities/genetics.ts
+++ b/src/utilities/genetics.ts
@@ -23,8 +23,14 @@ export function createGamete(org: Organism): Gamete {
   };
 }
 
-export function fertilize(motherGamete: Gamete, fatherGamete: Gamete): Organism {
-  const genotype = `${motherGamete.allele}${fatherGamete.allele}` as "RR" | "RC" | "CR" | "CC";
+export function fertilize(motherGamete: Gamete, fatherGamete: Gamete, chanceOfMutations: number): Organism {
+  const mAllele = (Math.random() < chanceOfMutations)
+                  ? motherGamete.allele === "R" ? "C" : "R"
+                  : motherGamete.allele;
+  const fAllele = (Math.random() < chanceOfMutations)
+                  ? fatherGamete.allele === "R" ? "C" : "R"
+                  : fatherGamete.allele;
+  const genotype = `${mAllele}${fAllele}` as "RR" | "RC" | "CR" | "CC";
   const sex = fatherGamete.sexChromosome === "X" ? "female" : "male";
 
   return {
@@ -33,11 +39,11 @@ export function fertilize(motherGamete: Gamete, fatherGamete: Gamete): Organism 
   };
 }
 
-export function breed(mother: Organism, father: Organism): Organism {
+export function breed(mother: Organism, father: Organism, chanceOfMutations: number): Organism {
   const motherGamete = createGamete(mother);
   const fatherGamete = createGamete(father);
 
-  return fertilize(motherGamete, fatherGamete);
+  return fertilize(motherGamete, fatherGamete, chanceOfMutations);
 }
 
 export function genotypeHTMLLabel(genotype: string): string {


### PR DESCRIPTION
This PR adds the ability to author mutation settings that work on the heredity level.  From the authoring page, users can enable a mutation checkbox, set the initial state of the checkbox, and specify the chance of mutation percentage.  Mutations appear in the nest pair litters when the breed button is pushed an litter offspring are created.

There are open issues regarding the percentages shown in the pie chart, but these are universal to all of the pie chart instances and are better dealt with in a separate PR.