### PR TITLE
Pie charts slider

### DIFF
--- a/src/components/charts/chart.sass
+++ b/src/components/charts/chart.sass
@@ -94,7 +94,11 @@
 
       .chart-container
         position: absolute
-        bottom: 59px
+        bottom: 75px
+
+      .line-chart-controls
+        position: absolute
+        bottom: 55px
 
     .top-chart
       display: flex

--- a/src/components/charts/chart.sass
+++ b/src/components/charts/chart.sass
@@ -100,6 +100,14 @@
         position: absolute
         bottom: 55px
 
+      .pointer-container
+        width: 352px
+        margin-left: 52px
+        height: 0px
+
+        .pointer
+          transform: translate(-50%, 6px)
+
     .top-chart
       display: flex
       justify-content: space-around
@@ -107,6 +115,13 @@
       .pie
         display: flex
         align-items: center
+        position: relative
+
+        .pointer
+          position: absolute
+          left: 13px
+          top: 28px
+
         .label
           width: 48px
           height: 48px
@@ -125,3 +140,11 @@
           border-color: $color-simdata-amber-light1
         &:nth-of-type(2) .pie-chart
           border-color: $color-simdata-amber-dark1
+
+
+  .pointer
+    width: 0
+    height: 0
+    border-left: 10px solid transparent
+    border-right: 10px solid transparent
+    border-top: 17px solid $color-simdata-amber-dark1

--- a/src/components/charts/chart.tsx
+++ b/src/components/charts/chart.tsx
@@ -15,7 +15,6 @@ interface IChartProps {
   height?: number;
   isPlaying: boolean;
   hideTitle?: boolean;
-  onLineChartSliderDragChange?: (value: number) => void;
 }
 
 interface IChartState {}
@@ -24,10 +23,7 @@ interface IChartState {}
 export class Chart extends React.Component<IChartProps, IChartState> {
 
   public render() {
-    const { chartType, chartData, width, height, isPlaying, hideTitle, onLineChartSliderDragChange } = this.props;
-    if (chartType === "line" && !onLineChartSliderDragChange) {
-      throw Error("Slider drag change handler is required for line charts");
-    }
+    const { chartType, chartData, width, height, isPlaying, hideTitle } = this.props;
     const chart = chartType === "line" ?
       <LineChart
         chartData={chartData}
@@ -35,7 +31,6 @@ export class Chart extends React.Component<IChartProps, IChartState> {
         height={height}
         isPlaying={isPlaying}
         hideTitle={hideTitle}
-        onSliderDragChange={onLineChartSliderDragChange!}
         data-test="line-chart" />
       :
       <BarChart

--- a/src/components/charts/chart.tsx
+++ b/src/components/charts/chart.tsx
@@ -15,6 +15,7 @@ interface IChartProps {
   height?: number;
   isPlaying: boolean;
   hideTitle?: boolean;
+  onLineChartSliderDragChange?: (value: number) => void;
 }
 
 interface IChartState {}
@@ -23,7 +24,10 @@ interface IChartState {}
 export class Chart extends React.Component<IChartProps, IChartState> {
 
   public render() {
-    const { chartType, chartData, width, height, isPlaying, hideTitle } = this.props;
+    const { chartType, chartData, width, height, isPlaying, hideTitle, onLineChartSliderDragChange } = this.props;
+    if (chartType === "line" && !onLineChartSliderDragChange) {
+      throw Error("Slider drag change handler is required for line charts");
+    }
     const chart = chartType === "line" ?
       <LineChart
         chartData={chartData}
@@ -31,6 +35,7 @@ export class Chart extends React.Component<IChartProps, IChartState> {
         height={height}
         isPlaying={isPlaying}
         hideTitle={hideTitle}
+        onSliderDragChange={onLineChartSliderDragChange!}
         data-test="line-chart" />
       :
       <BarChart

--- a/src/components/charts/line-chart-controls.tsx
+++ b/src/components/charts/line-chart-controls.tsx
@@ -39,11 +39,16 @@ export class LineChartControls extends BaseComponent<IChartControlProps, IChartC
     return nextState;
   }
 
-  public state: IChartControlState = {
-    scrubberPosition: 0,
-    scrubberMin: 0,
-    scrubberMax: 0
-  };
+  public constructor(props: IChartControlProps) {
+    super(props);
+
+    const lastPoint = Math.max(0, this.props.chartData.pointCount - 1);
+    this.state = {
+      scrubberMin: 0,
+      scrubberMax: lastPoint,
+      scrubberPosition: lastPoint
+    };
+  }
 
   public render() {
     const { isDisabled } = this.props;

--- a/src/components/charts/line-chart-controls.tsx
+++ b/src/components/charts/line-chart-controls.tsx
@@ -13,6 +13,7 @@ import "rc-slider/assets/index.css";
 interface IChartControlProps {
   chartData: ChartDataModelType;
   isPlaying: boolean;
+  onDragChange: (value: number) => void;
 }
 
 interface IChartControlState {
@@ -78,20 +79,12 @@ export class LineChartControls extends BaseComponent<IChartControlProps, IChartC
   }
 
   private handleDragChange = (value: number) => {
-    const { chartData } = this.props;
+    const { chartData, onDragChange } = this.props;
 
-    // slider covers whole dataset
-    // retrieve maxPoints for subset based on percentage along of the slider
-    const sliderPercentage = value / chartData.pointCount;
-    const dataRangeMax = chartData.pointCount - chartData.maxPoints;
-
-    if (dataRangeMax > 0) {
-      const startIdx = Math.round(sliderPercentage * dataRangeMax);
-      chartData.setDataSetSubset(startIdx, chartData.maxPoints);
-      this.setState({
-        scrubberPosition: value,
-        scrubberMax: chartData.pointCount
-      });
-    }
+    this.setState({
+      scrubberPosition: value,
+      scrubberMax: chartData.pointCount
+    });
+    onDragChange(value);
   }
 }

--- a/src/components/charts/line-chart-controls.tsx
+++ b/src/components/charts/line-chart-controls.tsx
@@ -30,9 +30,10 @@ export class LineChartControls extends BaseComponent<IChartControlProps, IChartC
     const nextState: IChartControlState = {} as any;
 
     if (isPlaying) {
-      nextState.scrubberPosition = chartData.pointCount;
-      if (prevState.scrubberMax !== chartData.pointCount) {
-        nextState.scrubberMax = chartData.pointCount;
+      const lastPoint = chartData.pointCount - 1;
+      nextState.scrubberPosition = lastPoint;
+      if (prevState.scrubberMax !== lastPoint) {
+        nextState.scrubberMax = lastPoint;
       }
     }
     return nextState;
@@ -75,11 +76,10 @@ export class LineChartControls extends BaseComponent<IChartControlProps, IChartC
   }
 
   private handleDragChange = (value: number) => {
-    const { chartData, onDragChange } = this.props;
+    const { onDragChange } = this.props;
 
     this.setState({
-      scrubberPosition: value,
-      scrubberMax: chartData.pointCount
+      scrubberPosition: value
     });
     onDragChange(value);
   }

--- a/src/components/charts/line-chart-controls.tsx
+++ b/src/components/charts/line-chart-controls.tsx
@@ -30,9 +30,6 @@ export class LineChartControls extends BaseComponent<IChartControlProps, IChartC
 
     if (isPlaying) {
       nextState.scrubberPosition = chartData.pointCount;
-      if (chartData.subsetIdx !== -1) {
-        chartData.setDataSetSubset(-1, chartData.maxPoints);
-      }
       if (prevState.scrubberMax !== chartData.pointCount) {
         nextState.scrubberMax = chartData.pointCount;
       }

--- a/src/components/charts/line-chart-controls.tsx
+++ b/src/components/charts/line-chart-controls.tsx
@@ -47,7 +47,6 @@ export class LineChartControls extends BaseComponent<IChartControlProps, IChartC
     const { chartData, isPlaying } = this.props;
     const { scrubberPosition, scrubberMin, scrubberMax } = this.state;
     const pos = scrubberPosition ? scrubberPosition : 0;
-    const timelineVisible = chartData.maxPoints > 0 && chartData.pointCount > chartData.maxPoints;
 
     const trackStyle = { backgroundColor: colors.chartColor5, height: 10 };
     const handleStyle = {
@@ -58,20 +57,16 @@ export class LineChartControls extends BaseComponent<IChartControlProps, IChartC
     const railStyle = { backgroundColor: colors.chartColor7, height: 10 };
 
     return (
-      <div className="line-chart-controls" id="line-chart-controls">
-        {timelineVisible &&
-          <Slider className="scrubber"
-          trackStyle={trackStyle}
-          handleStyle={handleStyle}
-          railStyle={railStyle}
-          onChange={this.handleDragChange}
-          min={scrubberMin}
-          max={scrubberMax}
-          value={pos}
-          disabled={isPlaying}
-          />
-        }
-      </div>
+      <Slider className="scrubber"
+        trackStyle={trackStyle}
+        handleStyle={handleStyle}
+        railStyle={railStyle}
+        onChange={this.handleDragChange}
+        min={scrubberMin}
+        max={scrubberMax}
+        value={pos}
+        disabled={isPlaying}
+      />
     );
   }
 

--- a/src/components/charts/line-chart-controls.tsx
+++ b/src/components/charts/line-chart-controls.tsx
@@ -13,6 +13,7 @@ import "rc-slider/assets/index.css";
 interface IChartControlProps {
   chartData: ChartDataModelType;
   isPlaying: boolean;
+  isDisabled: boolean;
   onDragChange: (value: number) => void;
 }
 
@@ -44,11 +45,14 @@ export class LineChartControls extends BaseComponent<IChartControlProps, IChartC
   };
 
   public render() {
-    const { chartData, isPlaying } = this.props;
+    const { isDisabled } = this.props;
     const { scrubberPosition, scrubberMin, scrubberMax } = this.state;
     const pos = scrubberPosition ? scrubberPosition : 0;
 
-    const trackStyle = { backgroundColor: colors.chartColor5, height: 10 };
+    const trackStyle = {
+      backgroundColor: isDisabled ? colors.disabledColor5 :  colors.chartColor5,
+      height: 10
+    };
     const handleStyle = {
       borderColor: colors.chartColor6,
       height: 20,
@@ -65,7 +69,7 @@ export class LineChartControls extends BaseComponent<IChartControlProps, IChartC
         min={scrubberMin}
         max={scrubberMax}
         value={pos}
-        disabled={isPlaying}
+        disabled={isDisabled}
       />
     );
   }

--- a/src/components/charts/line-chart.tsx
+++ b/src/components/charts/line-chart.tsx
@@ -7,7 +7,6 @@ import { ChartOptions } from "chart.js";
 import * as ChartAnnotation from "chartjs-plugin-annotation";
 import { ChartColors } from "../../models/spaces/charts/chart-data-set";
 import { hexToRGBValue } from "../../utilities/color-utils";
-import { LineChartControls } from "./line-chart-controls";
 import { BaseComponent } from "../base";
 
 interface ILineProps {
@@ -16,7 +15,6 @@ interface ILineProps {
   height?: number;
   isPlaying: boolean;
   hideTitle?: boolean;
-  onSliderDragChange: (value: number) => void;
 }
 
 interface ILineState { }
@@ -146,7 +144,7 @@ export class LineChart extends BaseComponent<ILineProps, ILineState> {
   }
 
   public render() {
-    const { chartData, width, height, isPlaying, onSliderDragChange } = this.props;
+    const { chartData, width, height } = this.props;
     const chartDisplay = lineData(chartData);
     const minMaxValues = chartData.minMaxAll;
     const options: ChartOptions = merge({}, defaultOptions, {
@@ -220,7 +218,6 @@ export class LineChart extends BaseComponent<ILineProps, ILineState> {
             plugins={[ChartAnnotation]}
           />
         </div>
-        <LineChartControls chartData={chartData} isPlaying={isPlaying} onDragChange={onSliderDragChange} />
       </div>
     );
   }

--- a/src/components/charts/line-chart.tsx
+++ b/src/components/charts/line-chart.tsx
@@ -16,6 +16,7 @@ interface ILineProps {
   height?: number;
   isPlaying: boolean;
   hideTitle?: boolean;
+  onSliderDragChange: (value: number) => void;
 }
 
 interface ILineState { }
@@ -145,7 +146,7 @@ export class LineChart extends BaseComponent<ILineProps, ILineState> {
   }
 
   public render() {
-    const { chartData, width, height, isPlaying } = this.props;
+    const { chartData, width, height, isPlaying, onSliderDragChange } = this.props;
     const chartDisplay = lineData(chartData);
     const minMaxValues = chartData.minMaxAll;
     const options: ChartOptions = merge({}, defaultOptions, {
@@ -219,7 +220,7 @@ export class LineChart extends BaseComponent<ILineProps, ILineState> {
             plugins={[ChartAnnotation]}
           />
         </div>
-        <LineChartControls chartData={chartData} isPlaying={isPlaying} />
+        <LineChartControls chartData={chartData} isPlaying={isPlaying} onDragChange={onSliderDragChange} />
       </div>
     );
   }

--- a/src/components/colors.scss
+++ b/src/components/colors.scss
@@ -19,6 +19,8 @@
   chartColor9:  $color5;
   chartColor10: $color6;
 
+  disabledColor5: $color1-2;
+
   colorChartRed: $color-chart-red;
   colorChartYellow: $color-chart-yellow;
   colorDataMouseBrownLightRep: $color-data-mousebrown-light-rep;

--- a/src/components/spaces/populations/populations-charts.tsx
+++ b/src/components/spaces/populations/populations-charts.tsx
@@ -53,6 +53,13 @@ export class PopulationsCharts extends BaseComponent<IProps, IState>  {
     if (this.disposer) this.disposer();
   }
 
+  public componentWillReact() {
+    const { isPlaying, chartData } = this.props;
+    if (isPlaying && chartData.subsetIdx !== -1) {
+      chartData.setDataSetSubset(-1, chartData.maxPoints);
+    }
+  }
+
   public render() {
     const { chartData, isPlaying } = this.props;
     const model = this.stores.populations.model as MousePopulationsModelType;

--- a/src/components/spaces/populations/populations-charts.tsx
+++ b/src/components/spaces/populations/populations-charts.tsx
@@ -144,13 +144,15 @@ export class PopulationsCharts extends BaseComponent<IProps, IState>  {
     const text = initialData ? "Initial: 0 months" : `Current: ${date} months`;
     // create single array of points, either the first of each dataset or the last
     let data = this.props.chartData.dataSets.filter(ds => ds.display).map(ds => {
-        const point = ds.dataPoints[pointIdx];
-        const value = point && !isNaN(point.a2) ? point.a2 : 0;
-        return {
-          label: ds.name,
-          value,
-          color: ds.color as string
-        };
+      // individual datasets may have fewer points
+      const _pointIdx = pointIdx === ds.dataPoints.length ? ds.dataPoints.length - 1 : pointIdx;
+      const point = ds.dataPoints[_pointIdx];
+      const value = point && !isNaN(point.a2) ? point.a2 : 0;
+      return {
+        label: ds.name,
+        value,
+        color: ds.color as string
+      };
     }) as PieChartData[];
     data = data.filter(d => d.value);
 
@@ -198,7 +200,7 @@ export class PopulationsCharts extends BaseComponent<IProps, IState>  {
     this.setState({pieChartComparisonIdx});
 
     if (!showMaxPoints) {
-      const startIdx = Math.max(pieChartComparisonIdx - chartData.maxPoints, 0);
+      const startIdx = Math.max((pieChartComparisonIdx + 1) - chartData.maxPoints, 0);
       chartData.setDataSetSubset(startIdx, chartData.maxPoints);
     }
   }

--- a/src/components/spaces/populations/populations-charts.tsx
+++ b/src/components/spaces/populations/populations-charts.tsx
@@ -163,7 +163,7 @@ export class PopulationsCharts extends BaseComponent<IProps, IState>  {
       const point = ds.dataPoints[_pointIdx];
       const value = point && !isNaN(point.a2) ? point.a2 : 0;
       return {
-        label: ds.name,
+        label: ds.name.replace(/ .*/, ""),      // take only first word of label (e.g. "Dark brown" => "Dark")
         value,
         color: ds.color as string
       };

--- a/src/components/spaces/populations/populations-charts.tsx
+++ b/src/components/spaces/populations/populations-charts.tsx
@@ -73,7 +73,8 @@ export class PopulationsCharts extends BaseComponent<IProps, IState>  {
     const toggleButtonTitle = showMaxPoints ? "Show Recent Data" : "Show All Data";
     const topChartClassName = "top-chart" + (showPieChart ? "" : " hidden");
     const bottomChartClassName = "bottom-chart" + (showPieChart ? " small" : "");
-    const timelineVisible = showPieChart || (chartData.maxPoints > 0 && chartData.pointCount > chartData.maxPoints);
+    const sliderIsDisabled = isPlaying ||
+      (!showPieChart && !(chartData.maxPoints > 0 && chartData.pointCount > chartData.maxPoints));
     return (
       <div className="chart-container">
         <div className="chart-header">
@@ -111,13 +112,12 @@ export class PopulationsCharts extends BaseComponent<IProps, IState>  {
               height={this.state.lineChartHeight}
             />
             <div className="line-chart-controls" id="line-chart-controls">
-              {timelineVisible &&
               <LineChartControls
                 chartData={chartData}
                 isPlaying={isPlaying}
+                isDisabled={sliderIsDisabled}
                 onDragChange={this.handleSliderDragChange}
               />
-              }
             </div>
           </div>
         </div>

--- a/src/components/spaces/populations/populations-charts.tsx
+++ b/src/components/spaces/populations/populations-charts.tsx
@@ -75,6 +75,15 @@ export class PopulationsCharts extends BaseComponent<IProps, IState>  {
     const bottomChartClassName = "bottom-chart" + (showPieChart ? " small" : "");
     const sliderIsDisabled = isPlaying ||
       (!showPieChart && !(chartData.maxPoints > 0 && chartData.pointCount > chartData.maxPoints));
+
+    const { pieChartComparisonIdx } = this.state;
+    let pointerPercent = 0;
+    const pointIdx = pieChartComparisonIdx === -1 ? chartData.pointCount - 1 : pieChartComparisonIdx;
+    if (this.props.chartData.dataSets[0].dataPoints[pointIdx]) {
+      const pointerVal = this.props.chartData.dataSets[0].dataPoints[pointIdx].a1;
+      pointerPercent = (pointerVal / chartData.minMaxAll.maxA1) * 100;
+    }
+
     return (
       <div className="chart-container">
         <div className="chart-header">
@@ -111,6 +120,11 @@ export class PopulationsCharts extends BaseComponent<IProps, IState>  {
               hideTitle={true}
               height={this.state.lineChartHeight}
             />
+            { showPieChart &&
+            <div className="pointer-container">
+              <div className="pointer" style={{marginLeft: pointerPercent + "%"}} />
+            </div>
+            }
             <div className="line-chart-controls" id="line-chart-controls">
               <LineChartControls
                 chartData={chartData}
@@ -158,6 +172,9 @@ export class PopulationsCharts extends BaseComponent<IProps, IState>  {
 
     return (
       <div className="pie">
+        { !initialData &&
+        <div className="pointer" />
+        }
         <div className="label">{ text }</div>
         <div>
           <PieChart data={data}/>

--- a/src/components/spaces/populations/populations-charts.tsx
+++ b/src/components/spaces/populations/populations-charts.tsx
@@ -7,6 +7,7 @@ import { BaseComponent } from "../../base";
 import { MousePopulationsModelType } from "../../../models/spaces/populations/mouse-model/mouse-populations-model";
 import { onAction } from "mobx-state-tree";
 import { IDisposer } from "mobx-state-tree/dist/utils";
+import { LineChartControls } from "../../charts/line-chart-controls";
 
 const MAX_LINE_CHART_HEIGHT = 400;
 const MIN_LINE_CHART_HEIGHT = 250;
@@ -67,6 +68,7 @@ export class PopulationsCharts extends BaseComponent<IProps, IState>  {
     const toggleButtonTitle = showMaxPoints ? "Show Recent Data" : "Show All Data";
     const topChartClassName = "top-chart" + (showPieChart ? "" : " hidden");
     const bottomChartClassName = "bottom-chart" + (showPieChart ? " small" : "");
+    const timelineVisible = chartData.maxPoints > 0 && chartData.pointCount > chartData.maxPoints;
     return (
       <div className="chart-container">
         <div className="chart-header">
@@ -102,8 +104,16 @@ export class PopulationsCharts extends BaseComponent<IProps, IState>  {
               isPlaying={isPlaying}
               hideTitle={true}
               height={this.state.lineChartHeight}
-              onLineChartSliderDragChange={this.handleSliderDragChange}
             />
+            <div className="line-chart-controls" id="line-chart-controls">
+              {timelineVisible &&
+              <LineChartControls
+                chartData={chartData}
+                isPlaying={isPlaying}
+                onDragChange={this.handleSliderDragChange}
+              />
+              }
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/spaces/populations/populations-charts.tsx
+++ b/src/components/spaces/populations/populations-charts.tsx
@@ -211,13 +211,20 @@ export class PopulationsCharts extends BaseComponent<IProps, IState>  {
   private handleSliderDragChange = (value: number) => {
     const { chartData } = this.props;
     const model = this.stores.populations.model as MousePopulationsModelType;
-    const { showMaxPoints } = model;
+    const { showMaxPoints, showPieChart } = model;
 
     const pieChartComparisonIdx = Math.min(value, chartData.pointCount - 1);
     this.setState({pieChartComparisonIdx});
 
     if (!showMaxPoints) {
-      const startIdx = Math.max((pieChartComparisonIdx + 1) - chartData.maxPoints, 0);
+      let startIdx;
+      if (showPieChart) {
+        startIdx = Math.max((pieChartComparisonIdx + 1) - chartData.maxPoints, 0);
+      } else {
+        const slidableRange = chartData.pointCount - chartData.maxPoints;
+        const sliderPercentage = value / chartData.pointCount;
+        startIdx = Math.round(sliderPercentage * slidableRange);
+      }
       chartData.setDataSetSubset(startIdx, chartData.maxPoints);
     }
   }

--- a/src/components/spaces/populations/populations-charts.tsx
+++ b/src/components/spaces/populations/populations-charts.tsx
@@ -89,8 +89,8 @@ export class PopulationsCharts extends BaseComponent<IProps, IState>  {
         <div className="chart-header">
           <div>
             { enablePieChart &&
-            <div className={"button-holder small-icon" + (showPieChart ? " active" : "")}>
-              <svg className="icon" onClick={toggleShowPieChart}>
+            <div className={"button-holder small-icon" + (showPieChart ? " active" : "")} onClick={toggleShowPieChart}>
+              <svg className="icon">
                 <use xlinkHref="#icon-pie-chart" />
               </svg>
             </div>

--- a/src/components/spaces/populations/populations-charts.tsx
+++ b/src/components/spaces/populations/populations-charts.tsx
@@ -95,6 +95,7 @@ export class PopulationsCharts extends BaseComponent<IProps, IState>  {
               isPlaying={isPlaying}
               hideTitle={true}
               height={this.state.lineChartHeight}
+              onLineChartSliderDragChange={this.handleSliderDragChange}
             />
           </div>
         </div>
@@ -159,5 +160,17 @@ export class PopulationsCharts extends BaseComponent<IProps, IState>  {
       this.setChartHeight(Math.min(height + sizeStep, MAX_LINE_CHART_HEIGHT));
       requestAnimationFrame(this.animateLineChartHeight);
     }
+  }
+
+  private handleSliderDragChange = (value: number) => {
+    const { chartData } = this.props;
+
+    // slider covers whole dataset
+    // retrieve maxPoints for subset based on percentage along of the slider
+    const dataRangeMax = chartData.pointCount - chartData.maxPoints;
+
+    const sliderPercentage = value / chartData.pointCount;
+    const startIdx = Math.round(sliderPercentage * dataRangeMax);
+    chartData.setDataSetSubset(startIdx, chartData.maxPoints);
   }
 }

--- a/src/models/spaces/populations/mouse-model/mouse-populations-model.ts
+++ b/src/models/spaces/populations/mouse-model/mouse-populations-model.ts
@@ -30,6 +30,8 @@ const chartNames = {
   alleles: "Alleles vs Time"
 };
 
+const kRecentDataMaxPoints = 25;
+
 const chartData = {
   name: chartNames.color,
   dataSets: [
@@ -37,7 +39,7 @@ const chartData = {
       name: "Light Brown",
       dataPoints: [],
       color: dataColors.white.mice,
-      maxPoints: 25,
+      maxPoints: kRecentDataMaxPoints,
       initialMaxA1: 12,
       fixedMinA2: 0,
       fixedMaxA2: 50,
@@ -50,7 +52,7 @@ const chartData = {
       name: "Medium Brown",
       dataPoints: [],
       color: dataColors.neutral.mice,
-      maxPoints: 25,
+      maxPoints: kRecentDataMaxPoints,
       initialMaxA1: 12,
       fixedMinA2: 0,
       fixedMaxA2: 50,
@@ -63,7 +65,7 @@ const chartData = {
       name: "Dark Brown",
       dataPoints: [],
       color: dataColors.brown.mice,
-      maxPoints: 25,
+      maxPoints: kRecentDataMaxPoints,
       initialMaxA1: 12,
       fixedMinA2: 0,
       fixedMaxA2: 50,
@@ -76,7 +78,7 @@ const chartData = {
       name: "RᴸRᴸ Mice",
       dataPoints: [],
       color: dataColors.white.mice,
-      maxPoints: 25,
+      maxPoints: kRecentDataMaxPoints,
       initialMaxA1: 12,
       fixedMinA2: 0,
       fixedMaxA2: 100,
@@ -90,7 +92,7 @@ const chartData = {
       name: "RᴸRᴰ Mice",
       dataPoints: [],
       color: dataColors.neutral.mice,
-      maxPoints: 25,
+      maxPoints: kRecentDataMaxPoints,
       initialMaxA1: 12,
       fixedMinA2: 0,
       fixedMaxA2: 100,
@@ -104,7 +106,7 @@ const chartData = {
       name: "RᴰRᴸ Mice",
       dataPoints: [],
       color: dataColors.neutral.mice,
-      maxPoints: 25,
+      maxPoints: kRecentDataMaxPoints,
       initialMaxA1: 12,
       fixedMinA2: 0,
       fixedMaxA2: 100,
@@ -118,7 +120,7 @@ const chartData = {
       name: "RᴰRᴰ Mice",
       dataPoints: [],
       color: dataColors.brown.mice,
-      maxPoints: 25,
+      maxPoints: kRecentDataMaxPoints,
       initialMaxA1: 12,
       fixedMinA2: 0,
       fixedMaxA2: 100,
@@ -132,7 +134,7 @@ const chartData = {
       name: "Rᴸ Alleles",
       dataPoints: [],
       color: dataColors.white.mice,
-      maxPoints: 25,
+      maxPoints: kRecentDataMaxPoints,
       initialMaxA1: 12,
       fixedMinA2: 0,
       fixedMaxA2: 100,
@@ -146,7 +148,7 @@ const chartData = {
       name: "Rᴰ Alleles",
       dataPoints: [],
       color: dataColors.brown.mice,
-      maxPoints: 25,
+      maxPoints: kRecentDataMaxPoints,
       initialMaxA1: 12,
       fixedMinA2: 0,
       fixedMaxA2: 100,
@@ -258,7 +260,7 @@ export const MousePopulationsModel = types
     }
     function displayRecentPoints() {
       self.chartData.dataSets.forEach((dataSet: any) => {
-        dataSet.setMaxDataPoints(20);
+        dataSet.setMaxDataPoints(kRecentDataMaxPoints);
       });
     }
 


### PR DESCRIPTION
Updates the slider to control a pointer, which updates the values in the right-hand pie chart.

Note, this slider works slightly differently in each of four different states:

1. **No pie charts, All points**: Disabled slider
2. **No pie charts, Recent points**: As before: slider from 0-100% shifts chart to see from start to end
3. **Pie charts, All points**: Slider from 0-100% updates right chart from 0-100%
4. **Pie charts, Recent points**: Slider from 0-100% updates right chart from 0-100%, chart shifts so long as right-most point can be the pointer-point, and then remains static while pointer moves within the first 12 months of data.