### PR TITLE
Style loading text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15712,9 +15712,9 @@
       }
     },
     "organelle": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/organelle/-/organelle-0.0.13.tgz",
-      "integrity": "sha512-k9eAIb3/64FYm9pF6au7uGK1hJOHV8c+FB6FLdnNBLfwQXm7CxCK0UiMQ4CdlPvHssNA6tPl94SaHLyjwITvlA==",
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/organelle/-/organelle-0.0.15.tgz",
+      "integrity": "sha512-oZu4tfh86+AekJyxV64kz3lvs4eP+Tgw3pPcoktjQ/FpGtqIsr7C0xRTfsMHR2tOGko7tsKojNlrCnGA6stX0A==",
       "requires": {
         "babel-polyfill": "^6.16.0",
         "fabric": "2.0.0-rc.4",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "mobx": "^5.5.0",
     "mobx-react": "^5.2.8",
     "mobx-state-tree": "^3.4.0",
-    "organelle": "0.0.13",
+    "organelle": "0.0.15",
     "patternomaly": "^1.3.2",
     "populations-react": "0.0.3",
     "populations.js": "^0.1.13",

--- a/src/components/spaces/organisms/organelle-wrapper.tsx
+++ b/src/components/spaces/organisms/organelle-wrapper.tsx
@@ -25,7 +25,7 @@ interface OrganelleWrapperState {
 }
 
 const SUBSTANCE_ADDITION_MS = 3500;
-const MODEL_HEIGHT = 362;
+const MODEL_HEIGHT = 320;
 const MODEL_WIDTH = 580;
 
 type SelectorInfo = {


### PR DESCRIPTION
Makes loading text white and centered.

Getting Fabric.js to correctly load the Ubuntu font proved to be a pain. Instead this simply uses sans-serif.