### PR TITLE
Make populations, organism models optional; Start to setup peas unit

### DIFF
--- a/cypress/integration/deer-mice-ui.test.ts
+++ b/cypress/integration/deer-mice-ui.test.ts
@@ -1,0 +1,25 @@
+context("Test Deer Mice Unit UI", () => {
+  describe("Top Bar", () => {
+    it("should show 'Deer Mice'", () => {
+      const params = encodeURIComponent(JSON.stringify({unit: "mouse", topBar: true}));
+      cy.visit(`/?${params}`);
+      cy.get(".top-bar").should("be.visible")
+        .and("contain", "Deer Mice");
+    });
+  });
+
+  describe("Breeding space", () => {
+    it("should show correct title", () => {
+      const authoring = {
+        unit: "mouse",
+        ui: {
+          investigationPanelSpace: "breeding"
+        }
+      };
+      const params = encodeURIComponent(JSON.stringify(authoring));
+      cy.visit(`/?${params}`);
+      cy.get(".header .title").should("be.visible")
+        .and("contain", "Explore: Nesting Pairs");
+    });
+  });
+});

--- a/cypress/integration/peas-ui.test.ts
+++ b/cypress/integration/peas-ui.test.ts
@@ -1,0 +1,25 @@
+context("Test Peas Unit UI", () => {
+  describe("Top Bar", () => {
+    it("should show 'Peas'", () => {
+      const params = encodeURIComponent(JSON.stringify({unit: "pea", topBar: true}));
+      cy.visit(`/?${params}`);
+      cy.get(".top-bar").should("be.visible")
+        .and("contain", "Peas");
+    });
+  });
+
+  describe("Breeding space", () => {
+    it("should show correct title", () => {
+      const authoring = {
+        unit: "pea",
+        ui: {
+          investigationPanelSpace: "breeding"
+        }
+      };
+      const params = encodeURIComponent(JSON.stringify(authoring));
+      cy.visit(`/?${params}`);
+      cy.get(".header .title").should("be.visible")
+        .and("contain", "Greenhouse");
+    });
+  });
+});

--- a/src/authoring-schema.json
+++ b/src/authoring-schema.json
@@ -5,13 +5,13 @@
     "unit": {
       "title": "Unit",
       "type": "string",
-      "oneOf": [
-        {
-          "enum": [
-            "mouse"
-          ],
-          "title": "Mouse"
-        }
+      "enum": [
+        "mouse",
+        "pea"
+      ],
+      "enumNames": [
+        "Mouse",
+        "Pea"
       ]
     },
     "topBar": {
@@ -294,5 +294,8 @@
         }
       }
     }
-  }
+  },
+  "required": [
+    "unit"
+  ]
 }

--- a/src/authoring.d.ts
+++ b/src/authoring.d.ts
@@ -5,8 +5,7 @@
  * and run json-schema-to-typescript to regenerate this file.
  */
 
-export type Unit = Mouse;
-export type Mouse = "mouse";
+export type Unit = "mouse" | "pea";
 export type ShowTopBar = boolean;
 export type ShowPopulationsSpace = boolean;
 export type ShowBreedingSpace = boolean;
@@ -35,7 +34,7 @@ export type TimeToShowBodySteps = number;
 export type EnableColorChart = boolean;
 export type EnableGenotypeChart = boolean;
 export type EnableAllelesChart = boolean;
-export type EnablePieChart = boolean;
+export type EnablePieCharts = boolean;
 export type InstructionsAsMarkdown1 = string;
 export type ShowMysteryLocationLabels = boolean;
 export type ShowMysterySubstanceLabels = boolean;
@@ -51,7 +50,7 @@ export type EnableMouseGenotypesPieChart = boolean;
 export type EnableMouseSexPieChart = boolean;
 
 export interface ConnectedBioAuthoring {
-  unit?: Unit;
+  unit: Unit;
   topBar?: ShowTopBar;
   ui?: InvestigationSpaces;
   backpack?: InitialBackpack;
@@ -89,7 +88,7 @@ export interface PopulationsModel {
   enableColorChart?: EnableColorChart;
   enableGenotypeChart?: EnableGenotypeChart;
   enableAllelesChart?: EnableAllelesChart;
-  enablePieChart?: EnablePieChart;
+  enablePieChart?: EnablePieCharts;
   [k: string]: any;
 }
 export interface InitialMousePopulation {

--- a/src/components/authoring.tsx
+++ b/src/components/authoring.tsx
@@ -78,9 +78,6 @@ export const defaultAuthoring: ConnectedBioAuthoring = {
 };
 
 const uiSchema = {
-  curriculum: {
-    "ui:readonly": true
-  },
   backpack: {
     "ui:options": {
       addable: true,

--- a/src/components/left-nav-panel.tsx
+++ b/src/components/left-nav-panel.tsx
@@ -33,25 +33,29 @@ export class LeftNavPanelComponent extends BaseComponent<IProps, IState> {
   }
 
   private renderExploreButtons = () => {
-    const {ui} = this.stores;
+    const {ui, populations, organisms, breeding} = this.stores;
+    const showPopulationSpace = ui.showPopulationSpace && populations;
+    const showOrganismSpace = ui.showOrganismSpace && organisms;
+    const showBreedingSpace = ui.showBreedingSpace && breeding;
+    const showDNASpace = false;   // eventually use ui.showDNASpace && dna
     return (
       <div className="button-holder investigate" data-test="explore-options">
-        {ui.showPopulationSpace &&
+        {showPopulationSpace &&
         <ExploreButtonComponent
           space={"populations"}
           title={"Population"}
         /> }
-        {ui.showOrganismSpace &&
+        {showOrganismSpace &&
         <ExploreButtonComponent
           space={"organism"}
           title={"Organism"}
         /> }
-        {ui.showBreedingSpace &&
+        {showBreedingSpace &&
         <ExploreButtonComponent
           space={"breeding"}
           title={"Heredity"}
         /> }
-        {ui.showDNASpace &&
+        {showDNASpace &&
         <ExploreButtonComponent
           space={"dna"}
           title={"DNA"}

--- a/src/components/spaces/breeding-space.tsx
+++ b/src/components/spaces/breeding-space.tsx
@@ -7,6 +7,7 @@ import { RightPanelType } from "../../models/ui";
 import { BreedingContainer } from "./breeding/breeding-container";
 import { BreedingData } from "./breeding/breeding-data";
 import { InspectPanel } from "../inspect-panel";
+import { units } from "../../models/units";
 
 interface InspectContent {
   title: string;
@@ -50,9 +51,12 @@ export class BreedingSpaceComponent extends BaseComponent<IProps, IState> {
       }
     })();
 
+    const unitDef = units[this.stores.unit];
+    const title = unitDef.breeding.title;
+
     return (
       <TwoUpDisplayComponent
-        leftTitle="Explore: Nesting Pairs"
+        leftTitle={title}
         leftPanel={<BreedingContainer />}
         rightTitle={rightPanelTitle}
         rightPanel={rightPanelContent}

--- a/src/components/spaces/organisms-space.tsx
+++ b/src/components/spaces/organisms-space.tsx
@@ -15,6 +15,7 @@ import { getAminoAcidsFromCodons } from "./proteins/util/amino-acid-utils";
 import { CollectButtonComponent } from "../collect-button";
 import ChromosomeViewer from "./organisms/chromosome-viewer";
 import { OrganismsSpaceModelType } from "../../models/spaces/organisms/organisms-space";
+import { units } from "../../models/units";
 
 interface IProps extends IBaseProps {}
 interface IState {
@@ -163,6 +164,9 @@ export class OrganismsSpaceComponent extends BaseComponent<IProps, IState> {
       });
     }
 
+    const unitDef = units[this.stores.unit];
+    const title = unitDef.organism.title;
+
     return (
       <div className="fullwidth">
         <CollectButtonComponent
@@ -171,7 +175,7 @@ export class OrganismsSpaceComponent extends BaseComponent<IProps, IState> {
           placeable={activeMouse != null}
         />
         <TwoUpDisplayComponent
-          leftTitle="Explore: Organism"
+          leftTitle={title}
           leftPanel={<OrganismsContainer
             rowIndex={rowIndex}
             disableZoom={this.state.isZooming}

--- a/src/components/spaces/organisms-space.tsx
+++ b/src/components/spaces/organisms-space.tsx
@@ -14,6 +14,7 @@ import { extractCodons } from "./proteins/util/dna-utils";
 import { getAminoAcidsFromCodons } from "./proteins/util/amino-acid-utils";
 import { CollectButtonComponent } from "../collect-button";
 import ChromosomeViewer from "./organisms/chromosome-viewer";
+import { OrganismsSpaceModelType } from "../../models/spaces/organisms/organisms-space";
 
 interface IProps extends IBaseProps {}
 interface IState {
@@ -32,46 +33,44 @@ export class OrganismsSpaceComponent extends BaseComponent<IProps, IState> {
   }
 
   public render() {
-    const organismsComponent1 = this.getOrganismsRow(0);
-    const organismsComponent2 = this.getOrganismsRow(1);
+    const { organisms } = this.stores;
+    if (!organisms) return null;
+    const organismsComponent1 = this.getOrganismsRow(0, organisms);
+    const organismsComponent2 = this.getOrganismsRow(1, organisms);
 
     return (
       <FourUpDisplayComponent topRow={organismsComponent1} bottomRow={organismsComponent2} />
     );
   }
 
-  private toggleShowingAminoAcidsOnViewer = (rowIndex: number) => {
-    const { organisms } = this.stores;
+  private toggleShowingAminoAcidsOnViewer = (rowIndex: number, organisms: OrganismsSpaceModelType) => {
     const row = organisms.rows[rowIndex];
     return () =>
       row.setShowProteinAminoAcidsOnProtein(!row.showProteinAminoAcidsOnProtein);
   }
 
-  private toggleShowDNA = (rowIndex: number) => {
-    const { organisms } = this.stores;
+  private toggleShowDNA = (rowIndex: number, organisms: OrganismsSpaceModelType) => {
     const row = organisms.rows[rowIndex];
     return () =>
       row.setShowProteinDNA(!row.showProteinDNA);
   }
 
-  private handleSetSelectStartPercent = (percent: number) => {
-    const { organisms } = this.stores;
+  private handleSetSelectStartPercent = (percent: number, organisms: OrganismsSpaceModelType) => {
     // set on both simultaneously
-    organisms.setProteinSliderStartPercent(percent);
+    return () => organisms.setProteinSliderStartPercent(percent);
   }
 
-  private handleUpdateSelectedAminoAcidIndex = (selectedAminoAcidIndex: number) => {
-    const { organisms } = this.stores;
-    organisms.setProteinSliderSelectedAminoAcidIndex(Math.round(selectedAminoAcidIndex));
+  private handleUpdateSelectedAminoAcidIndex = (organisms: OrganismsSpaceModelType) => {
+    return (selectedAminoAcidIndex: number) =>
+      organisms.setProteinSliderSelectedAminoAcidIndex(Math.round(selectedAminoAcidIndex));
   }
 
-  private toggleShowInfoBox = () => {
-    const { organisms } = this.stores;
-    organisms.setShowInfoBox(!organisms.showProteinInfoBox);
+  private toggleShowInfoBox = (organisms: OrganismsSpaceModelType) => {
+    return () => organisms.setShowInfoBox(!organisms.showProteinInfoBox);
   }
 
-  private getOrganismsRow(rowIndex: number) {
-    const { backpack, organisms } = this.stores;
+  private getOrganismsRow(rowIndex: number, organisms: OrganismsSpaceModelType) {
+    const { backpack } = this.stores;
     const { activeMouse } = backpack;
     const { proteinSliderSelectedAminoAcidIndex, showProteinInfoBox } = organisms;
     const row = organisms.rows[rowIndex];
@@ -114,10 +113,10 @@ export class OrganismsSpaceComponent extends BaseComponent<IProps, IState> {
               showInfoBox={showProteinInfoBox}
               showAminoAcidsOnProtein={showProteinAminoAcidsOnProtein}
               showDNA={showProteinDNA}
-              toggleShowDNA={this.toggleShowDNA(rowIndex)}
-              toggleShowingAminoAcidsOnProtein={this.toggleShowingAminoAcidsOnViewer(rowIndex)}
-              setSelectedAminoAcidIndex={this.handleUpdateSelectedAminoAcidIndex}
-              toggleShowInfoBox={this.toggleShowInfoBox}
+              toggleShowDNA={this.toggleShowDNA(rowIndex, organisms)}
+              toggleShowingAminoAcidsOnProtein={this.toggleShowingAminoAcidsOnViewer(rowIndex, organisms)}
+              setSelectedAminoAcidIndex={this.handleUpdateSelectedAminoAcidIndex(organisms)}
+              toggleShowInfoBox={this.toggleShowInfoBox(organisms)}
             />;
             } else {
               return (
@@ -168,7 +167,7 @@ export class OrganismsSpaceComponent extends BaseComponent<IProps, IState> {
       <div className="fullwidth">
         <CollectButtonComponent
           backpackMouse={organismsMouse && organismsMouse.backpackMouse}
-          clickClose={this.clickClose(rowIndex)}
+          clickClose={this.clickClose(rowIndex, organisms)}
           placeable={activeMouse != null}
         />
         <TwoUpDisplayComponent
@@ -182,7 +181,7 @@ export class OrganismsSpaceComponent extends BaseComponent<IProps, IState> {
           dataIconEnabled={true}
           informationIconEnabled={true}
           selectedRightPanel={rightPanel}
-          onClickRightIcon={this.setRightPanel(rowIndex)}
+          onClickRightIcon={this.setRightPanel(rowIndex, organisms)}
           spaceClass="organism"
           rowNumber={rowIndex}
           rightPanelButtons={buttons}
@@ -191,13 +190,11 @@ export class OrganismsSpaceComponent extends BaseComponent<IProps, IState> {
     );
   }
 
-  private setRightPanel = (rowIndex: number) => (panelType: RightPanelType) => {
-    const { organisms } = this.stores;
+  private setRightPanel = (rowIndex: number, organisms: OrganismsSpaceModelType) => (panelType: RightPanelType) => {
     organisms.rows[rowIndex].setRightPanel(panelType);
   }
 
-  private clickClose = (rowIndex: number) => () => {
-    const { organisms } = this.stores;
+  private clickClose = (rowIndex: number, organisms: OrganismsSpaceModelType) => () => {
     organisms.clearRowBackpackMouse(rowIndex);
   }
 

--- a/src/components/spaces/organisms-space.tsx
+++ b/src/components/spaces/organisms-space.tsx
@@ -9,7 +9,7 @@ import { InstructionsComponent } from "../instructions";
 import { OrganismsContainer } from "./organisms/organisms-container";
 import ProteinViewer from "./proteins/protein-viewer";
 import { RightPanelType } from "../../models/ui";
-import { kOrganelleInfo } from "../../models/spaces/organisms/organisms-space";
+import { kOrganelleInfo } from "../../models/spaces/organisms/mouse/mouse-cell-data";
 import { extractCodons } from "./proteins/util/dna-utils";
 import { getAminoAcidsFromCodons } from "./proteins/util/amino-acid-utils";
 import { CollectButtonComponent } from "../collect-button";

--- a/src/components/spaces/organisms/manipulation-controls.tsx
+++ b/src/components/spaces/organisms/manipulation-controls.tsx
@@ -18,6 +18,7 @@ export class ManipulationControls extends BaseComponent<IProps, IState> {
 
   public render() {
     const { organisms } = this.stores;
+    if (!organisms) return null;
     const row = this.getControlsRow();
     const hormoneClass = "hormone " + (row.selectedSubstance === "hormone" ? "active" : "");
     const signalProteinClass = "signal-protein " + (row.selectedSubstance === "signalProtein" ? "active" : "");
@@ -160,7 +161,7 @@ export class ManipulationControls extends BaseComponent<IProps, IState> {
   private getControlsRow = () => {
     const { organisms } = this.stores;
     const { rowIndex } = this.props;
-    return organisms.rows[rowIndex];
+    return organisms!.rows[rowIndex];
   }
 
   private handleAssayClick = () => {

--- a/src/components/spaces/organisms/nucleus-view.tsx
+++ b/src/components/spaces/organisms/nucleus-view.tsx
@@ -92,7 +92,9 @@ export class NucleusView extends BaseComponent<IProps, IState> {
   }
 
   public componentWillMount() {
-    this.disposer = onAction(this.stores.organisms, this.updatingModel);
+    if (this.stores.organisms) {
+      this.disposer = onAction(this.stores.organisms, this.updatingModel);
+    }
   }
 
   public componentWillUnmount() {
@@ -262,7 +264,7 @@ export class NucleusView extends BaseComponent<IProps, IState> {
   get row() {
     const { organisms } = this.stores;
     const { rowIndex } = this.props;
-    return organisms.rows[rowIndex];
+    return organisms!.rows[rowIndex];
   }
 
   get mouseId() {

--- a/src/components/spaces/organisms/organelle-wrapper.tsx
+++ b/src/components/spaces/organisms/organelle-wrapper.tsx
@@ -131,7 +131,7 @@ export class OrganelleWrapper extends BaseComponent<OrganelleWrapperProps, Organ
 
   public organelleClick(organelleType: OrganelleType, location: {x: number, y: number}) {
     const { organisms } = this.stores;
-    const row = organisms.rows[this.props.rowIndex];
+    const row = organisms!.rows[this.props.rowIndex];
     if (row.mode === "assay") {
       row.setActiveAssay(organelleType);
       row.setRightPanel("data");        // auto-switch to data
@@ -208,7 +208,7 @@ export class OrganelleWrapper extends BaseComponent<OrganelleWrapperProps, Organ
   public addHormone(organelleType: OrganelleType, location: {x: number, y: number}) {
     const { rowIndex } = this.props;
     const { organisms } = this.stores;
-    const zoom = organisms.rows[rowIndex].zoomLevel;
+    const zoom = organisms!.rows[rowIndex].zoomLevel;
     const species = zoom === "cell" ? "hormoneDot" : "hexagon";
     const inIntercell = organelleType === "extracellular";
     const state = inIntercell ? "find_path_from_anywhere" : "diffuse";
@@ -225,7 +225,7 @@ export class OrganelleWrapper extends BaseComponent<OrganelleWrapperProps, Organ
     location.x -= 17;
     location.y += 3;
 
-    if (organisms.rows[rowIndex].zoomLevel === "receptor") {
+    if (organisms!.rows[rowIndex].zoomLevel === "receptor") {
       const inIntercell = organelleType === "extracellular";
       const species = "gProteinPart";
       const state = inIntercell ? "find_flowing_path" : "in_cell_from_click";
@@ -235,6 +235,7 @@ export class OrganelleWrapper extends BaseComponent<OrganelleWrapperProps, Organ
 
   public render() {
     const {organisms} = this.stores;
+    if (!organisms) return  null;
     const {mode, zoomLevel} = this.props;
     const { getOrganelleLabel } = organisms;
     const hoveredOrganelle = organisms.rows[this.props.rowIndex].hoveredOrganelle;
@@ -317,6 +318,8 @@ export class OrganelleWrapper extends BaseComponent<OrganelleWrapperProps, Organ
     }
     const { zoomLevel } = this.props;
     const { organisms } = this.stores;
+    if (!organisms) return;
+
     const row = organisms.rows[this.props.rowIndex];
     const { organismsMouse } = row;
     const { modelProperties } = organismsMouse!;
@@ -392,6 +395,7 @@ export class OrganelleWrapper extends BaseComponent<OrganelleWrapperProps, Organ
 
     model.on("model.step", () => {
       const { organisms } = this.stores;
+      if (!organisms) return;
       const { rowIndex } = this.props;
       const { organismsMouse } = organisms.rows[rowIndex];
       if (!organismsMouse) {
@@ -442,18 +446,18 @@ export class OrganelleWrapper extends BaseComponent<OrganelleWrapperProps, Organ
     model.on("view.hover.enter", (evt: any) => {
       const {organisms} = this.stores;
       const hoveredOrganelle = this.getOrganelleFromMouseEvent(evt);
-      organisms.rows[this.props.rowIndex].setHoveredOrganelle(hoveredOrganelle);
+      organisms!.rows[this.props.rowIndex].setHoveredOrganelle(hoveredOrganelle);
 
       const target = this.getZoomTargetFromMouseEvent(evt);
       if (target) {
-        organisms.rows[this.props.rowIndex].setHoveredZoomTarget(target);
+        organisms!.rows[this.props.rowIndex].setHoveredZoomTarget(target);
       }
     });
 
     model.on("view.hover.exit", (evt: any) => {
       const {organisms} = this.stores;
       if (evt.target._organelle.matches({selector: ".zoom"})) {
-        organisms.rows[this.props.rowIndex].setHoveredZoomTarget();
+        organisms!.rows[this.props.rowIndex].setHoveredZoomTarget();
       }
     });
 
@@ -583,7 +587,7 @@ export class OrganelleWrapper extends BaseComponent<OrganelleWrapperProps, Organ
       .filter(organelle => {
         const organelleInfo = this.organelleSelectorInfo[organelle];
         const visibleModes = organelleInfo.visibleModes;
-        return !visibleModes || visibleModes.indexOf(organisms.rows[this.props.rowIndex].mode) > -1;
+        return !visibleModes || visibleModes.indexOf(organisms!.rows[this.props.rowIndex].mode) > -1;
       });
     return possibleTargets.find((t) => {
       return evt.target._organelle.matches({selector: this.organelleSelectorInfo[t].selector});
@@ -593,7 +597,7 @@ export class OrganelleWrapper extends BaseComponent<OrganelleWrapperProps, Organ
   private resetHoveredOrganelle = () => {
     const {organisms} = this.stores;
     const {rowIndex} = this.props;
-    organisms.rows[rowIndex].setHoveredOrganelle(undefined);
+    organisms!.rows[rowIndex].setHoveredOrganelle(undefined);
   }
 
   private getOpaqueSelector(organelleType: OrganelleType) {

--- a/src/components/spaces/organisms/organelle-wrapper.tsx
+++ b/src/components/spaces/organisms/organelle-wrapper.tsx
@@ -7,7 +7,7 @@ import * as Receptor from "./cell-models/receptor.json";
 import { BaseComponent } from "../../base";
 import "./organelle-wrapper.sass";
 import { ModeType, ZoomLevelType, ZoomTargetType } from "../../../models/spaces/organisms/organisms-row.js";
-import { OrganelleType } from "../../../models/spaces/organisms/organisms-mouse.js";
+import { OrganelleType } from "../../../models/spaces/organisms/mouse/organisms-mouse.js";
 
 interface OrganelleWrapperProps {
   zoomLevel: ZoomLevelType;

--- a/src/components/spaces/organisms/organisms-container.tsx
+++ b/src/components/spaces/organisms/organisms-container.tsx
@@ -10,6 +10,7 @@ import { OrganelleWrapper } from "./organelle-wrapper";
 import { ManipulationControls } from "./manipulation-controls";
 import { NucleusView } from "./nucleus-view";
 import { DEFAULT_MODEL_WIDTH } from "../../..";
+import { OrganismsSpaceModelType } from "../../../models/spaces/organisms/organisms-space";
 
 interface IProps extends IBaseProps {
   rowIndex: number;
@@ -39,6 +40,7 @@ export class OrganismsContainer extends BaseComponent<IProps, IState> {
   public render() {
     const { rowIndex } = this.props;
     const { organisms } = this.stores;
+    if (!organisms) return null;
     const organismsRow = organisms.rows[rowIndex];
     const { zoomLevel, mode } = organismsRow;
     const showTargetZoom = zoomLevel === "cell";
@@ -46,10 +48,10 @@ export class OrganismsContainer extends BaseComponent<IProps, IState> {
     return (
       <div className="organisms-container" data-test="organism-view-container">
         {
-          this.organismZoomedView(organismsRow, zoomLevel, rowIndex, mode)
+          this.organismZoomedView(organisms, organismsRow, zoomLevel, rowIndex, mode)
         }
         <div className="organism-controls">
-          <ZoomControl handleZoom={this.zoomChange} rowIndex={rowIndex} showTargetZoom={showTargetZoom}
+          <ZoomControl handleZoom={this.zoomChange(organisms)} rowIndex={rowIndex} showTargetZoom={showTargetZoom}
             disable={this.props.disableZoom} />
           <ManipulationControls rowIndex={rowIndex} disableNucleusControls={this.state.nucleusAnimating} />
         </div>
@@ -57,8 +59,7 @@ export class OrganismsContainer extends BaseComponent<IProps, IState> {
     );
   }
 
-  private zoomChange = (zoomChange: number) => {
-    const { organisms } = this.stores;
+  private zoomChange = (organisms: OrganismsSpaceModelType) => (zoomChange: number) => {
     const { rowIndex } = this.props;
     const organismsRow = organisms.rows[rowIndex];
 
@@ -90,16 +91,15 @@ export class OrganismsContainer extends BaseComponent<IProps, IState> {
     organismsRow.setZoomLevel(defaultZoomLevelByIndex[nextIdx]);
   }
 
-  private zoomToLevel = (level: ZoomLevelType) => {
-    const { organisms } = this.stores;
+  private zoomToLevel = (organisms: OrganismsSpaceModelType) => (level: ZoomLevelType) => {
     const { rowIndex } = this.props;
     const organismsRow = organisms.rows[rowIndex];
     organismsRow.setZoomLevel(level);
   }
 
   // We explicitly pass down organismsRow and zoomLevel separately
-  private organismZoomedView = (organismsRow: OrganismsRowModelType, zoomLevel: ZoomLevelType, rowIndex: number,
-                                mode: ModeType) => {
+  private organismZoomedView = (organisms: OrganismsSpaceModelType, organismsRow: OrganismsRowModelType,
+                                zoomLevel: ZoomLevelType, rowIndex: number, mode: ModeType) => {
     const { organismsMouse, previousZoomLevel } = organismsRow;
     const width = DEFAULT_MODEL_WIDTH;
     const { isZoomingIntoOrg, cellModelLoaded } = this.state;
@@ -121,7 +121,7 @@ export class OrganismsContainer extends BaseComponent<IProps, IState> {
             {
               organismsMouse != null &&
                 <OrganelleWrapper zoomLevel={zoomLevel} elementName={`organelle-wrapper-${rowIndex}`}
-                  rowIndex={rowIndex} width={width} mode={mode} handleZoomToLevel={this.zoomToLevel}
+                  rowIndex={rowIndex} width={width} mode={mode} handleZoomToLevel={this.zoomToLevel(organisms)}
                   onModelLoaded={this.cellModelLoaded}/>
             }
           </div>

--- a/src/components/spaces/populations-space.tsx
+++ b/src/components/spaces/populations-space.tsx
@@ -7,6 +7,7 @@ import { InstructionsComponent } from "../instructions";
 import { RightPanelType } from "../../models/ui";
 import { InspectPanel } from "../inspect-panel";
 import { PopulationsCharts } from "./populations/populations-charts";
+import { units } from "../../models/units";
 
 interface IProps extends IBaseProps {}
 interface IState {}
@@ -44,9 +45,12 @@ export class PopulationsSpaceComponent extends BaseComponent<IProps, IState> {
       }
     })();
 
+    const unitDef = units[this.stores.unit];
+    const title = unitDef.populations.title;
+
     return (
       <TwoUpDisplayComponent
-        leftTitle="Explore: Population"
+        leftTitle={title}
         leftPanel={<PopulationsComponent />}
         rightTitle={rightPanelTitle}
         rightPanel={rightPanelContent}

--- a/src/components/spaces/populations-space.tsx
+++ b/src/components/spaces/populations-space.tsx
@@ -17,6 +17,7 @@ export class PopulationsSpaceComponent extends BaseComponent<IProps, IState> {
 
   public render() {
     const { populations } = this.stores;
+    if (!populations) return null;
     const rightPanelType = populations.rightPanel;
     let rightPanelTitle = "";
     const rightPanelContent = (() => {
@@ -63,7 +64,9 @@ export class PopulationsSpaceComponent extends BaseComponent<IProps, IState> {
 
   private setRightPanel = (panelType: RightPanelType) => {
     const { populations } = this.stores;
-    populations.setRightPanel(panelType);
+    if (populations) {
+      populations.setRightPanel(panelType);
+    }
   }
 
 }

--- a/src/components/spaces/populations/populations-charts.tsx
+++ b/src/components/spaces/populations/populations-charts.tsx
@@ -33,6 +33,7 @@ export class PopulationsCharts extends BaseComponent<IProps, IState>  {
   public constructor(props: IProps) {
     super(props);
 
+    if (!this.stores.populations) return;
     const model = this.stores.populations.model as MousePopulationsModelType;
     const lineChartHeight = model.showPieChart ? MIN_LINE_CHART_HEIGHT : MAX_LINE_CHART_HEIGHT;
     this.state = {
@@ -44,6 +45,7 @@ export class PopulationsCharts extends BaseComponent<IProps, IState>  {
   }
 
   public componentDidMount() {
+    if (!this.stores.populations) return;
     this.disposer = onAction(this.stores.populations.model, call => {
       if (call.name === "toggleShowPieChart") {
         lastAnimationTime = Date.now();
@@ -67,6 +69,8 @@ export class PopulationsCharts extends BaseComponent<IProps, IState>  {
   }
 
   public render() {
+    if (!this.stores.populations) return null;
+
     const { chartData, isPlaying } = this.props;
     const model = this.stores.populations.model as MousePopulationsModelType;
     const { showMaxPoints, toggleShowMaxPoints, enablePieChart, showPieChart, toggleShowPieChart } = model;
@@ -189,7 +193,7 @@ export class PopulationsCharts extends BaseComponent<IProps, IState>  {
   }
 
   private animateLineChartHeight = () => {
-    const model = this.stores.populations.model as MousePopulationsModelType;
+    const model = this.stores.populations!.model as MousePopulationsModelType;
     const height = this.state.lineChartHeight;
     const now = Date.now();
     const timeStepPercent = (now - lastAnimationTime) / animationTime;
@@ -210,7 +214,7 @@ export class PopulationsCharts extends BaseComponent<IProps, IState>  {
 
   private handleSliderDragChange = (value: number) => {
     const { chartData } = this.props;
-    const model = this.stores.populations.model as MousePopulationsModelType;
+    const model = this.stores.populations!.model as MousePopulationsModelType;
     const { showMaxPoints, showPieChart } = model;
 
     const pieChartComparisonIdx = Math.min(value, chartData.pointCount - 1);

--- a/src/components/spaces/populations/populations-container.tsx
+++ b/src/components/spaces/populations/populations-container.tsx
@@ -28,7 +28,7 @@ export class PopulationsComponent extends BaseComponent<IProps, IState> {
   }
 
   public componentDidMount() {
-    if (firstMount) {
+    if (this.stores.populations && firstMount) {
       // only initialize the populations graph on the very first mount.
       // from then on, the graph will only be re-initialized when the user
       // explicitly resets the model
@@ -38,7 +38,7 @@ export class PopulationsComponent extends BaseComponent<IProps, IState> {
   }
 
   public componentWillUnmount() {
-    this.stores.populations.close();
+    if (this.stores.populations) this.stores.populations.close();
   }
 
   public render() {
@@ -168,15 +168,15 @@ export class PopulationsComponent extends BaseComponent<IProps, IState> {
   }
 
   private handleClickRunButton = () => {
-    this.stores.populations.togglePlay();
+    this.stores.populations!.togglePlay();
   }
 
   private handleClickInspectButton = () => {
-    this.stores.populations.toggleInteractionMode("inspect");
+    this.stores.populations!.toggleInteractionMode("inspect");
   }
 
   private handleClickResetButton = () => {
-    this.stores.populations.reset();
+    this.stores.populations!.reset();
   }
 
   private handleClickToolbarCheckbox = (button: ToolbarButton) => {
@@ -187,7 +187,7 @@ export class PopulationsComponent extends BaseComponent<IProps, IState> {
   }
 
   private handleClickSelect = () => {
-    this.stores.populations.toggleInteractionMode("select");
+    this.stores.populations!.toggleInteractionMode("select");
   }
 
   private handleAgentMouseEvent = (evt: AgentEnvironmentMouseEvent) => {
@@ -204,7 +204,7 @@ export class PopulationsComponent extends BaseComponent<IProps, IState> {
           });
           const added = backpack.addCollectedMouse(backpackMouse);
           if (added){
-            this.stores.populations.removeAgent(selectedMouse);
+            this.stores.populations!.removeAgent(selectedMouse);
           }
         } else if (evtType === "click" && populations.interactionMode === "inspect") {
           const selectedMouse = evt.agents.mice;

--- a/src/components/top-bar.tsx
+++ b/src/components/top-bar.tsx
@@ -1,5 +1,6 @@
 import { inject, observer } from "mobx-react";
 import * as React from "react";
+import { units } from "../models/units";
 import { BaseComponent, IBaseProps } from "./base";
 
 import "./top-bar.sass";
@@ -12,6 +13,7 @@ interface IState {}
 export class TopBarComponent extends BaseComponent<IProps, IState> {
 
   public render() {
+    const title = units[this.stores.unit].title;
 
     return (
       <div className="top-bar">
@@ -22,7 +24,7 @@ export class TopBarComponent extends BaseComponent<IProps, IState> {
             </svg>
           </div>
           <div className="title-holder" data-test="top-bar-title">
-            Deer Mice
+            { title }
           </div>
         </div>
       </div>

--- a/src/components/zoom-control.tsx
+++ b/src/components/zoom-control.tsx
@@ -4,6 +4,7 @@ import { BaseComponent, IBaseProps } from "./base";
 
 import "./zoom-control.sass";
 import { ZoomLevelType } from "../models/spaces/organisms/organisms-row";
+import { OrganismsSpaceModelType } from "../models/spaces/organisms/organisms-space";
 
 interface IProps extends IBaseProps {
   handleZoom: (zoomLevel: number) => void;
@@ -19,13 +20,15 @@ export class ZoomControl extends BaseComponent<IProps, IState> {
 
   public render() {
     const { showTargetZoom } = this.props;
+    const { organisms } = this.stores;
+    if (!organisms) return null;
 
     const row = this.getControlsRow();
     const targetClass = showTargetZoom ? " target sticky" : "";
     const activeClass = row.mode === "target-zoom" ? " active" : "";
 
-    const zoomInClass = "zoom-in" + this.getZoomClass(["organism", "cell"]) + targetClass + activeClass;
-    const zoomOutClass = "zoom-out" + this.getZoomClass(["cell", "receptor", "nucleus"]);
+    const zoomInClass = "zoom-in" + this.getZoomClass(["organism", "cell"], organisms) + targetClass + activeClass;
+    const zoomOutClass = "zoom-out" + this.getZoomClass(["cell", "receptor", "nucleus"], organisms);
     const zoomInIcon = "#icon-zoomin" + (showTargetZoom ? "-target" : "");
     return (
       <div className="zoom-container" data-test="zoom-container">
@@ -50,8 +53,7 @@ export class ZoomControl extends BaseComponent<IProps, IState> {
     );
   }
 
-  private getZoomClass = (enabledZooms: ZoomLevelType[]) => {
-    const { organisms } = this.stores;
+  private getZoomClass = (enabledZooms: ZoomLevelType[], organisms: OrganismsSpaceModelType) => {
     const { rowIndex, disable } = this.props;
     const row = organisms.rows[rowIndex];
     if (disable || row.zoomLevel === "cell" && !organisms.showZoomToNucleus && !organisms.showZoomToReceptor) {
@@ -85,6 +87,6 @@ export class ZoomControl extends BaseComponent<IProps, IState> {
   private getControlsRow = () => {
     const { organisms } = this.stores;
     const { rowIndex } = this.props;
-    return organisms.rows[rowIndex];
+    return organisms!.rows[rowIndex];
   }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -57,7 +57,9 @@ function initializeModel(studentData: UserSaveDataType) {
     };
     onSnapshot(stores.backpack, saveUserData);
     onSnapshot(stores.ui, saveUserData);
-    onSnapshot(stores.organisms, saveUserData);
+    if (stores.organisms) {
+      onSnapshot(stores.organisms, saveUserData);
+    }
     onSnapshot(stores.breeding, saveUserData);
 
     const outerWrapperStyle = { className: "outer-scale-wrapper" };

--- a/src/models/spaces/organisms/mouse/mouse-cell-data.ts
+++ b/src/models/spaces/organisms/mouse/mouse-cell-data.ts
@@ -1,0 +1,107 @@
+import { SubstanceInfo, OrganelleInfo } from "../organisms-space";
+import MouseProteins from "../../../../components/spaces/proteins/protein-specs/mouse-proteins";
+
+export const kSubstanceInfo: SubstanceInfo = {
+  hormone: {
+    displayName: "Hormone",
+    mysteryLabel: "substance D",
+    color: "#00cc99",
+    graphPattern: "diagonal"
+  },
+  signalProtein: {
+    displayName: "Activated SP",
+    mysteryLabel: "substance B",
+    color: "#29abe2",
+    graphPattern: "diagonal-right-left"
+  },
+  pheomelanin: {
+    displayName: "Pheomelanin",
+    mysteryLabel: "substance A",
+    color: "#dfc39d",
+  },
+  eumelanin: {
+    displayName: "Eumelanin",
+    mysteryLabel: "substance C",
+    color: "#5d3515",
+  },
+};
+
+// Cell models can be viewed here:
+// https://docs.google.com/spreadsheets/d/19f0nk-F3UQ_-A-agq5JnuhJXGCtFYMT_JcYCQkyqnQI/edit
+export const kOrganelleInfo: OrganelleInfo = {
+  nucleus: {
+    displayName: "Nucleus",
+    mysteryLabel: "Location 2",
+    substances: {}
+  },
+  cytoplasm: {
+    displayName: "Cytoplasm",
+    mysteryLabel: "Location 3",
+    substances: {
+      signalProtein: {
+        white: 0,
+        tan: 110,
+        brown: 170
+      }
+    }
+  },
+  golgi: {
+    displayName: "Golgi",
+    mysteryLabel: "",
+    substances: {}
+  },
+  extracellular: {
+    displayName: "Extracellular Space",
+    mysteryLabel: "Location 4",
+    substances: {
+      hormone: {
+        white: 125,
+        tan: 125,
+        brown: 125
+      }
+    }
+  },
+  melanosome: {
+    displayName: "Melanosome",
+    mysteryLabel: "Location 1",
+    substances: {
+      eumelanin: {
+        white: 0,
+        tan: 280,
+        brown: 340
+      },
+      pheomelanin: {
+        white: 317,
+        tan: 207,
+        brown: 147
+      }
+    }
+  },
+  receptor: {
+    displayName: "Receptor",
+    mysteryLabel: "",
+    substances: {}
+  },
+  receptorWorking: {
+    displayName: "Receptor",
+    mysteryLabel: "",
+    substances: {},
+    protein: MouseProteins.receptor.working
+  },
+  receptorBroken: {
+    displayName: "Receptor",
+    mysteryLabel: "",
+    substances: {},
+    protein: MouseProteins.receptor.broken
+  },
+  gate: {
+    displayName: "Gate",
+    mysteryLabel: "",
+    substances: {}
+  },
+  nearbyCell: {
+    displayName: "Nearby Cell",
+    mysteryLabel: "Location 5",
+    substances: {}
+  },
+};

--- a/src/models/spaces/organisms/mouse/organisms-mouse.ts
+++ b/src/models/spaces/organisms/mouse/organisms-mouse.ts
@@ -1,6 +1,6 @@
 import { types, Instance } from "mobx-state-tree";
-import { BackpackMouse } from "../../backpack-mouse";
-import { kOrganelleInfo } from "./organisms-space";
+import { BackpackMouse } from "../../../backpack-mouse";
+import { kOrganelleInfo } from "./mouse-cell-data";
 import { v4 as uuid } from "uuid";
 
 export const Organelle = types.enumeration("Organelle", [

--- a/src/models/spaces/organisms/organisms-row.ts
+++ b/src/models/spaces/organisms/organisms-row.ts
@@ -3,8 +3,9 @@ import { ChartDataModelType, ChartDataModel } from "../charts/chart-data";
 import { RightPanelTypeEnum, RightPanelType } from "../../ui";
 import { DataPoint, ChartDataSetModel, DataPointType, ChartDataSetModelType } from "../charts/chart-data-set";
 import { OrganismsMouseModel, Organelle, Substance, kSubstanceNames,
-  OrganelleType, SubstanceType } from "./organisms-mouse";
-import { kSubstanceInfo, OrganismsSpaceModel } from "./organisms-space";
+  OrganelleType, SubstanceType } from "./mouse/organisms-mouse";
+import { kSubstanceInfo } from "./mouse/mouse-cell-data";
+import { OrganismsSpaceModel } from "./organisms-space";
 
 export const Mode = types.enumeration("type", ["add", "subtract", "assay", "inspect", "target-zoom", "normal"]);
 export type ModeType = typeof Mode.Type;

--- a/src/models/spaces/organisms/organisms-space.ts
+++ b/src/models/spaces/organisms/organisms-space.ts
@@ -1,14 +1,14 @@
 import { types, Instance, resolveIdentifier } from "mobx-state-tree";
 import { ColorType, BackpackMouseType, BackpackMouse } from "../../backpack-mouse";
 import { ProteinSpec } from "../../../components/spaces/proteins/protein-viewer";
-import MouseProteins from "../../../components/spaces/proteins/protein-specs/mouse-proteins";
+import { kOrganelleInfo, kSubstanceInfo } from "./mouse/mouse-cell-data";
 import { RightPanelType } from "../../ui";
-import { OrganismsMouseModel, OrganelleType, SubstanceType } from "./organisms-mouse";
+import { OrganismsMouseModel, OrganelleType, SubstanceType } from "./mouse/organisms-mouse";
 import { OrganismsRowModel } from "./organisms-row";
 import { BackpackModelType } from "../../backpack";
 import { GraphPatternType } from "../charts/chart-data-set";
 
-type SubstanceInfo = {
+export type SubstanceInfo = {
   [substance in SubstanceType]: {
     displayName: string;
     mysteryLabel: string;
@@ -16,32 +16,8 @@ type SubstanceInfo = {
     graphPattern?: GraphPatternType;
   };
 };
-export const kSubstanceInfo: SubstanceInfo = {
-  hormone: {
-    displayName: "Hormone",
-    mysteryLabel: "substance D",
-    color: "#00cc99",
-    graphPattern: "diagonal"
-  },
-  signalProtein: {
-    displayName: "Activated SP",
-    mysteryLabel: "substance B",
-    color: "#29abe2",
-    graphPattern: "diagonal-right-left"
-  },
-  pheomelanin: {
-    displayName: "Pheomelanin",
-    mysteryLabel: "substance A",
-    color: "#dfc39d",
-  },
-  eumelanin: {
-    displayName: "Eumelanin",
-    mysteryLabel: "substance C",
-    color: "#5d3515",
-  },
-};
 
-type OrganelleInfo = {
+export type OrganelleInfo = {
   [organelle in OrganelleType]: {
     displayName: string;
     mysteryLabel: string;
@@ -52,86 +28,6 @@ type OrganelleInfo = {
     };
     protein?: ProteinSpec;
   };
-};
-
-// Cell models can be viewed here:
-// https://docs.google.com/spreadsheets/d/19f0nk-F3UQ_-A-agq5JnuhJXGCtFYMT_JcYCQkyqnQI/edit
-export const kOrganelleInfo: OrganelleInfo = {
-  nucleus: {
-    displayName: "Nucleus",
-    mysteryLabel: "Location 2",
-    substances: {}
-  },
-  cytoplasm: {
-    displayName: "Cytoplasm",
-    mysteryLabel: "Location 3",
-    substances: {
-      signalProtein: {
-        white: 0,
-        tan: 110,
-        brown: 170
-      }
-    }
-  },
-  golgi: {
-    displayName: "Golgi",
-    mysteryLabel: "",
-    substances: {}
-  },
-  extracellular: {
-    displayName: "Extracellular Space",
-    mysteryLabel: "Location 4",
-    substances: {
-      hormone: {
-        white: 125,
-        tan: 125,
-        brown: 125
-      }
-    }
-  },
-  melanosome: {
-    displayName: "Melanosome",
-    mysteryLabel: "Location 1",
-    substances: {
-      eumelanin: {
-        white: 0,
-        tan: 280,
-        brown: 340
-      },
-      pheomelanin: {
-        white: 317,
-        tan: 207,
-        brown: 147
-      }
-    }
-  },
-  receptor: {
-    displayName: "Receptor",
-    mysteryLabel: "",
-    substances: {}
-  },
-  receptorWorking: {
-    displayName: "Receptor",
-    mysteryLabel: "",
-    substances: {},
-    protein: MouseProteins.receptor.working
-  },
-  receptorBroken: {
-    displayName: "Receptor",
-    mysteryLabel: "",
-    substances: {},
-    protein: MouseProteins.receptor.broken
-  },
-  gate: {
-    displayName: "Gate",
-    mysteryLabel: "",
-    substances: {}
-  },
-  nearbyCell: {
-    displayName: "Nearby Cell",
-    mysteryLabel: "Location 5",
-    substances: {}
-  },
 };
 
 export function createOrganismsModel(organismsProps: any, backpack: BackpackModelType) {

--- a/src/models/spaces/organisms/organisms-space.ts
+++ b/src/models/spaces/organisms/organisms-space.ts
@@ -7,6 +7,7 @@ import { OrganismsMouseModel, OrganelleType, SubstanceType } from "./mouse/organ
 import { OrganismsRowModel } from "./organisms-row";
 import { BackpackModelType } from "../../backpack";
 import { GraphPatternType } from "../charts/chart-data-set";
+import { Unit } from "../../../authoring";
 
 export type SubstanceInfo = {
   [substance in SubstanceType]: {
@@ -30,16 +31,22 @@ export type OrganelleInfo = {
   };
 };
 
-export function createOrganismsModel(organismsProps: any, backpack: BackpackModelType) {
-  if (organismsProps.organismsMice) {
-    organismsProps.organismsMice = organismsProps.organismsMice.map((organismMouse: any) => {
-      return {
-        ...organismMouse,
-        backpackMouse: resolveIdentifier(BackpackMouse, backpack, organismMouse.backpackMouse)
-      };
-    });
-  }
-  return OrganismsSpaceModel.create(organismsProps);
+export function createOrganismsModel(unit: Unit, organismsProps: any, backpack: BackpackModelType) {
+  switch (unit) {
+    case "pea":
+      return null;
+    case "mouse":
+    default:
+      if (organismsProps.organismsMice) {
+        organismsProps.organismsMice = organismsProps.organismsMice.map((organismMouse: any) => {
+          return {
+            ...organismMouse,
+            backpackMouse: resolveIdentifier(BackpackMouse, backpack, organismMouse.backpackMouse)
+          };
+        });
+      }
+      return OrganismsSpaceModel.create(organismsProps);
+    }
 }
 
 export const OrganismsSpaceModel = types

--- a/src/models/spaces/populations/populations.ts
+++ b/src/models/spaces/populations/populations.ts
@@ -8,8 +8,10 @@ import { Unit } from "../../../authoring";
 const ModelsUnion = types.union(MousePopulationsModel);
 type ModelsUnionType = MousePopulationsModelType;
 
-export function createPopulationsModel(unit: Unit = "mouse", authoring: any): PopulationsModelType {
+export function createPopulationsModel(unit: Unit, authoring: any): PopulationsModelType | null {
   switch (unit) {
+    case "pea":
+      return null;
     case "mouse":
     default:
       return PopulationsModel.create({

--- a/src/models/stores.ts
+++ b/src/models/stores.ts
@@ -6,7 +6,7 @@ import { OrganismsSpaceModelType, createOrganismsModel } from "./spaces/organism
 import { BackpackMouseType } from "./backpack-mouse";
 import { ConnectedBioAuthoring } from "../authoring";
 import { QueryParams } from "../utilities/url-params";
-import { OrganismsMouseModelType } from "./spaces/organisms/organisms-mouse";
+import { OrganismsMouseModelType } from "./spaces/organisms/mouse/organisms-mouse";
 import { OrganismsRowModelType } from "./spaces/organisms/organisms-row";
 import { autorun } from "mobx";
 import { onAction } from "mobx-state-tree";

--- a/src/models/stores.ts
+++ b/src/models/stores.ts
@@ -20,7 +20,7 @@ const STUDENT_DATA_VERSION = 1;
 
 export interface IStores {
   ui: UIModelType;
-  populations: PopulationsModelType;
+  populations?: PopulationsModelType;
   backpack: BackpackModelType;
   organisms: OrganismsSpaceModelType;
   breeding: BreedingModelType;
@@ -62,13 +62,18 @@ export function createStores(initialModel: ConnectedBioModelCreationType): IStor
     }
   });
 
-  return {
+  const stores: IStores = {
     ui,
     backpack,
-    populations,
     organisms,
     breeding
   };
+
+  if (populations) {
+    stores.populations = populations;
+  }
+
+  return stores;
 }
 
 export interface UserSaveDataType {

--- a/src/models/stores.ts
+++ b/src/models/stores.ts
@@ -4,7 +4,7 @@ import { BackpackModel, BackpackModelType } from "./backpack";
 import { flatten } from "flat";
 import { OrganismsSpaceModelType, createOrganismsModel } from "./spaces/organisms/organisms-space";
 import { BackpackMouseType } from "./backpack-mouse";
-import { ConnectedBioAuthoring } from "../authoring";
+import { ConnectedBioAuthoring, Unit } from "../authoring";
 import { QueryParams } from "../utilities/url-params";
 import { OrganismsMouseModelType } from "./spaces/organisms/mouse/organisms-mouse";
 import { OrganismsRowModelType } from "./spaces/organisms/organisms-row";
@@ -13,12 +13,11 @@ import { onAction } from "mobx-state-tree";
 import { BreedingModelType, createBreedingModel, INestPair } from "./spaces/breeding/breeding";
 import { EnvironmentColorType } from "../models/spaces/breeding/breeding";
 
-export type Unit = "mouse";
-
 // allow for migration when needed
 const STUDENT_DATA_VERSION = 1;
 
 export interface IStores {
+  unit: Unit;
   ui: UIModelType;
   populations?: PopulationsModelType;
   backpack: BackpackModelType;
@@ -65,6 +64,7 @@ export function createStores(initialModel: ConnectedBioModelCreationType): IStor
   }
 
   const stores: IStores = {
+    unit: initialModel.unit,
     ui,
     backpack,
     breeding

--- a/src/models/units.ts
+++ b/src/models/units.ts
@@ -1,0 +1,52 @@
+import { Unit } from "../authoring";
+
+interface UnitDefinition {
+  title: string;
+  populations: {
+    title: string;
+  };
+  organism: {
+    title: string;
+  };
+  breeding: {
+    title: string;
+  };
+  dna: {
+    title: string;
+  };
+}
+
+type Units = Record<Unit, UnitDefinition>;
+
+export const units: Units = {
+  mouse: {
+    title: "Deer Mice",
+    populations: {
+      title: "Explore: Population",
+    },
+    organism: {
+      title: "Explore: Organism",
+    },
+    breeding: {
+      title: "Explore: Nesting Pairs",
+    },
+    dna: {
+      title: "Explore: DNA",
+    },
+  },
+  pea: {
+    title: "Peas",
+    populations: {
+      title: "Explore: Population",
+    },
+    organism: {
+      title: "Explore: Population",
+    },
+    breeding: {
+      title: "Greenhouse",
+    },
+    dna: {
+      title: "Explore: DNA",
+    },
+  }
+};

--- a/src/utilities/url-params.ts
+++ b/src/utilities/url-params.ts
@@ -10,10 +10,12 @@ let params: QueryParams;
 try {
   const queryString = location.search.length > 1
     ? decodeURIComponent(location.search.substring(1).replace("authoring", ""))
-    : "{}";
+    : `{unit: "mouse"}`;
   params = JSON.parse(queryString);
 } catch (e) {
-  params = {};
+  params = {
+    unit: "mouse"
+  };
 }
 
 if (location.search.indexOf("authoring") === 1) {


### PR DESCRIPTION
This introduces the start of some branching based on whether the unit is `"mouse"` or `"pea"`. The largest change is that there is no populations or organism model in the Pea unit (yet), and so this PR adds support for optional models.

It also just barely starts making some UI distinctions between the units (the titles), and adds one small refactoring of mouse-specific files.