### PR TITLE
Hide genotypes

### DIFF
--- a/src/authoring-schema.json
+++ b/src/authoring-schema.json
@@ -284,16 +284,24 @@
           "title": "Enable inspect gametes button",
           "type": "boolean"
         },
+        "showParentGenotype": {
+          "type": "boolean",
+          "title": "Show Parent Genotype"
+        },
+        "showOffspringGenotype": {
+          "type": "boolean",
+          "title": "Show Offspring Genotype"
+        },
         "enableColorChart": {
-          "title": "Enable mouse fur color pie chart",
+          "title": "Enable phenotype pie chart",
           "type": "boolean"
         },
         "enableGenotypeChart": {
-          "title": "Enable mouse genotypes pie chart",
+          "title": "Enable genotype pie chart",
           "type": "boolean"
         },
         "enableSexChart": {
-          "title": "Enable mouse sex pie chart",
+          "title": "Enable sex pie chart",
           "type": "boolean"
         }
       }

--- a/src/authoring.d.ts
+++ b/src/authoring.d.ts
@@ -46,6 +46,8 @@ export type EnableStudentMutationControl1 = boolean;
 export type BreedWithMutations1 = boolean;
 export type ChanceOfMutations1 = number;
 export type EnableInspectGametesButton = boolean;
+export type ShowParentGenotype = boolean;
+export type ShowOffspringGenotype = boolean;
 export type EnableMouseFurColorPieChart = boolean;
 export type EnableMouseGenotypesPieChart = boolean;
 export type EnableMouseSexPieChart = boolean;
@@ -131,6 +133,8 @@ export interface BreedingModel {
   breedWithMutations?: BreedWithMutations1;
   chanceOfMutations?: ChanceOfMutations1;
   enableInspectGametes?: EnableInspectGametesButton;
+  showParentGenotype?: ShowParentGenotype;
+  showOffspringGenotype?: ShowOffspringGenotype;
   enableColorChart?: EnableMouseFurColorPieChart;
   enableGenotypeChart?: EnableMouseGenotypesPieChart;
   enableSexChart?: EnableMouseSexPieChart;

--- a/src/components/authoring.tsx
+++ b/src/components/authoring.tsx
@@ -72,6 +72,8 @@ export const defaultAuthoring: ConnectedBioAuthoring = {
     breedWithMutations: false,
     chanceOfMutations: 2,
     enableInspectGametes: true,
+    showParentGenotype: true,
+    showOffspringGenotype: true,
     enableColorChart: true,
     enableGenotypeChart: true,
     enableSexChart: true

--- a/src/components/inspect-panel.tsx
+++ b/src/components/inspect-panel.tsx
@@ -81,6 +81,7 @@ export class InspectPanel extends BaseComponent<IProps, IState> {
   private renderMouse(mouse: BackpackMouseType, flip: boolean) {
     const mouseImage = mouse.getInspectImage(this.getContext());
     const showSex = units[mouse.species].species.showSexStack;
+    const showHetero = this.props.showGenotype;
     return (
       <div className="mouse-container">
         <StackedOrganism
@@ -89,7 +90,7 @@ export class InspectPanel extends BaseComponent<IProps, IState> {
           height={170}
           showSelection={false}
           showSex={showSex}
-          showHetero={true}
+          showHetero={showHetero}
           flipped={flip}
         />
         {this.renderOrganismInfo(mouse)}

--- a/src/components/spaces/breeding-space.tsx
+++ b/src/components/spaces/breeding-space.tsx
@@ -28,7 +28,7 @@ export class BreedingSpaceComponent extends BaseComponent<IProps, IState> {
 
   public render() {
     const { breeding } = this.stores;
-    const { rightPanel } = breeding;
+    const { rightPanel, showParentGenotype, showOffspringGenotype } = breeding;
     let rightPanelTitle = "";
     const rightPanelContent = (() => {
       switch (rightPanel) {
@@ -39,6 +39,7 @@ export class BreedingSpaceComponent extends BaseComponent<IProps, IState> {
         case "information":
           const content: InspectContent = this.getInspectedContent();
           rightPanelTitle = content.title;
+          const showGenotype = content.isOffspring ? showOffspringGenotype : showParentGenotype;
           return <InspectPanel
                   mouse1={content.mouse1}
                   mouse2={content.mouse2}
@@ -46,7 +47,7 @@ export class BreedingSpaceComponent extends BaseComponent<IProps, IState> {
                   pairMeta={content.pairMeta}
                   isOffspring={content.isOffspring}
                   isGamete={content.isGamete}
-                  showGenotype={true}
+                  showGenotype={showGenotype}
                  />;
         default:
           return null;

--- a/src/models/spaces/breeding/breeding.ts
+++ b/src/models/spaces/breeding/breeding.ts
@@ -407,7 +407,8 @@ export const BreedingModel = types
           value: self.showHeteroStack,
           action: (val: boolean) => {
             self.setShowHeteroStack(val);
-          }
+          },
+          enabled: self.showParentGenotype && self.showOffspringGenotype
         });
 
         buttons.push({

--- a/src/models/spaces/breeding/breeding.ts
+++ b/src/models/spaces/breeding/breeding.ts
@@ -257,6 +257,8 @@ export const BreedingModel = types
     showSexStack: false,
     showHeteroStack: false,
     breedWithMutations: false,
+    showParentGenotype: true,
+    showOffspringGenotype: true,
     enableStudentControlOfMutations: false,
     chanceOfMutations: types.number,
     interactionMode: types.optional(BreedingInteractionModeEnum, "breed"),


### PR DESCRIPTION
Add authoring option to hide genotypes in parent and/or offspring inspect panels.

Note that the genotypes are still visible elsewhere in the app (gamete toggle, genotype chart) but the author can disable those independently.

Parent genotype hidden in inspect:

http://connected-bio-spaces.concord.org/branch/hide-genotypes/index.html?%7B%22unit%22%3A%22pea%22%2C%22topBar%22%3Atrue%2C%22leftPanel%22%3Afalse%2C%22ui%22%3A%7B%22showBreedingSpace%22%3Atrue%2C%22investigationPanelSpace%22%3A%22breeding%22%7D%2C%22breeding%22%3A%7B%22showParentGenotype%22%3Afalse%2C%22showOffspringGenotype%22%3Atrue%7D%7D

Offspring genotype hidden:

http://connected-bio-spaces.concord.org/branch/hide-genotypes/index.html?%7B%22unit%22%3A%22pea%22%2C%22topBar%22%3Atrue%2C%22leftPanel%22%3Afalse%2C%22ui%22%3A%7B%22showBreedingSpace%22%3Atrue%2C%22investigationPanelSpace%22%3A%22breeding%22%7D%2C%22breeding%22%3A%7B%22showParentGenotype%22%3Atrue%2C%22showOffspringGenotype%22%3Afalse%7D%7D