### PR TITLE
Gametes toggle

### DIFF
--- a/src/components/inspect-panel.tsx
+++ b/src/components/inspect-panel.tsx
@@ -17,9 +17,9 @@ interface IProps extends IBaseProps {
   pairLabel: string;
   pairMeta?: string;
   isOffspring: boolean;
-  isGamete: boolean;
-  isPopulationInspect?: boolean;
+  context: InspectContext;
   showGenotype: boolean;
+  showGametes: boolean;
 }
 interface IState {}
 
@@ -38,7 +38,7 @@ export class InspectPanel extends BaseComponent<IProps, IState> {
         {(mouse1 && !mouse2) && this.renderInspectedMouse(mouse1)}
         {
           (species && species.inspectFooterProvider && mouse1) &&
-          species.inspectFooterProvider(this.getContext(), mouse1, mouse2)
+          species.inspectFooterProvider(this.props.context, mouse1, mouse2)
         }
       </div>
     );
@@ -60,18 +60,19 @@ export class InspectPanel extends BaseComponent<IProps, IState> {
   }
 
   private renderInspectedMouse(mouse: BackpackMouseType) {
-    const classModifiers = "single " + (this.props.isGamete ? "gamete " : "")
-    + (this.props.isPopulationInspect ? "population " : "")
-    + (this.props.isGamete && this.props.isOffspring ? "low " : "")
-    + (this.props.isOffspring ? "offspring " : "parent ")
+    const {showGametes, context, isOffspring} = this.props;
+    const classModifiers = "single " + (showGametes ? "gamete " : "")
+    + context + " "
+    + ((showGametes && isOffspring) ? "low " : "")
+    + (isOffspring ? "offspring " : "parent ")
     + mouse.sex;
     const containerClass = "pair-container " + classModifiers;
     const bgClass = "inspect-background " + classModifiers;
     const allowFlip = units[mouse.species].breeding.flipRightNestParent;
-    const flipImage = allowFlip && !this.props.isPopulationInspect && !this.props.isOffspring && mouse.sex === "male";
+    const flipImage = allowFlip && context !== "population" && !this.props.isOffspring && mouse.sex === "male";
     return(
       <div className={containerClass}>
-        { (this.props.isGamete && this.props.isOffspring) && this.renderGametePanel(mouse) }
+        { (this.props.showGametes && this.props.isOffspring) && this.renderGametePanel(mouse) }
         <div className={bgClass} />
         {this.renderMouse(mouse, flipImage)}
       </div>
@@ -79,7 +80,7 @@ export class InspectPanel extends BaseComponent<IProps, IState> {
   }
 
   private renderMouse(mouse: BackpackMouseType, flip: boolean) {
-    const mouseImage = mouse.getInspectImage(this.getContext());
+    const mouseImage = mouse.getInspectImage(this.props.context);
     const showSex = units[mouse.species].species.showSexStack;
     const showHetero = this.props.showGenotype;
     return (
@@ -100,9 +101,9 @@ export class InspectPanel extends BaseComponent<IProps, IState> {
 
   private renderOrganismInfo(org: BackpackMouseType) {
     const species = speciesDef(org.species);
-    const context = this.getContext();
+    const context = this.props.context;
 
-    return species.inspectInfoProvider(org, context, this.props.isGamete, this.props.showGenotype);
+    return species.inspectInfoProvider(org, context, this.props.showGametes, this.props.showGenotype);
   }
 
   private renderGametePanel = (mouse: BackpackMouseType) => {
@@ -122,14 +123,6 @@ export class InspectPanel extends BaseComponent<IProps, IState> {
         <img src={arrowImage} className="arrow" />
       </div>
     );
-  }
-
-  private getContext = () => {
-    const context: InspectContext =
-      this.props.isPopulationInspect ? "population" :
-      this.props.mouse2 ? "nest" :
-      this.props.isOffspring ? "offspring" : "parent";
-    return context;
   }
 }
 

--- a/src/components/spaces/breeding-space.tsx
+++ b/src/components/spaces/breeding-space.tsx
@@ -8,6 +8,7 @@ import { BreedingContainer } from "./breeding/breeding-container";
 import { BreedingData } from "./breeding/breeding-data";
 import { InspectPanel } from "../inspect-panel";
 import { units } from "../../models/units";
+import { InspectContext } from "../../models/backpack-mouse";
 
 interface InspectContent {
   title: string;
@@ -39,14 +40,18 @@ export class BreedingSpaceComponent extends BaseComponent<IProps, IState> {
         case "information":
           const content: InspectContent = this.getInspectedContent();
           rightPanelTitle = content.title;
+          const context: InspectContext = content.mouse2 ? "nest" :
+            content.isOffspring ? "offspring" : "parent";
           const showGenotype = content.isOffspring ? showOffspringGenotype : showParentGenotype;
+
           return <InspectPanel
                   mouse1={content.mouse1}
                   mouse2={content.mouse2}
                   pairLabel={content.label}
+                  context={context}
                   pairMeta={content.pairMeta}
                   isOffspring={content.isOffspring}
-                  isGamete={content.isGamete}
+                  showGametes={breeding.showingGametes}
                   showGenotype={showGenotype}
                  />;
         default:

--- a/src/components/spaces/breeding/breeding-container.tsx
+++ b/src/components/spaces/breeding/breeding-container.tsx
@@ -54,12 +54,12 @@ export class BreedingContainer extends BaseComponent<IProps, IState> {
                     + (breeding.interactionMode === "inspect" ? " inspect" : "")
                     + (breeding.interactionMode === "select" ? " select" : "")
                     + ((breeding.interactionMode === "breed" && showingNesting) ? " breed" : "")
-                    + ((breeding.interactionMode === "gametes" && !showingNesting) ? " gametes" : "");
+                    + ((breeding.showGametes && !showingNesting) ? " gametes" : "");
 
     const mainComponent = showingNesting ? <NestingView /> : <BreedingView />;
     const switchLevelsButtonLabel = showingNesting ? "Breeding" : breedingUnit.nestButtonTitle;
     const switchLevelsIcon = showingNesting ? "breed" : "nests";
-    const showGametes = breeding.interactionMode === "gametes";
+    const showGametes = breeding.showingGametes;
     const hideGametesClass = "inner-box inner-button left" + (!showGametes ? " selected" : " unselected");
     const showGametesClass = "inner-box inner-button right" + (showGametes ? " selected" : " unselected");
 
@@ -92,7 +92,7 @@ export class BreedingContainer extends BaseComponent<IProps, IState> {
                     <div className="label">Show</div>
                   </div>
                 </div>
-                <div className="label">Inspect Gametes</div>
+                <div className="label">Gametes</div>
               </button>
               <button className={"breeding-button " + inspectButtonClass}
                       onClick={this.handleClickInspectButton} data-test="inspect-button">
@@ -158,10 +158,10 @@ export class BreedingContainer extends BaseComponent<IProps, IState> {
   }
 
   private handleClickHideGametesButton = () => {
-    this.stores.breeding.toggleInteractionMode("gametes");
+    this.stores.breeding.hideGametes();
   }
 
   private handleClickShowGametesButton = () => {
-    this.stores.breeding.toggleInteractionMode("gametes");
+    this.stores.breeding.showGametes();
   }
 }

--- a/src/components/spaces/breeding/breeding-data-nest-panel.tsx
+++ b/src/components/spaces/breeding/breeding-data-nest-panel.tsx
@@ -60,7 +60,7 @@ export class BreedingDataNestPanel extends BaseComponent<IProps, IState> {
                   {species.getGenotypeHTMLLabel(nestPair.leftMouse.genotype)}
                 </span>
                 <span className="right-mouse">
-                  {species.getGenotypeHTMLLabel(nestPair.leftMouse.genotype)}
+                  {species.getGenotypeHTMLLabel(nestPair.rightMouse.genotype)}
                 </span>
               </div>
             }

--- a/src/components/spaces/breeding/breeding-view.sass
+++ b/src/components/spaces/breeding/breeding-view.sass
@@ -82,6 +82,12 @@
           &:hover .hover-view
             opacity: .75
             height: 45px
+          &.no-label
+            height: 26px
+            .hover-view, .hover-view.tall
+              height: 26px
+            &:hover .hover-view
+              height: 26px
           &:hover .icon.egg
             background-image: url("../../../assets/icons/egg-hi.svg")
           &:hover .icon.sperm

--- a/src/components/spaces/breeding/breeding-view.tsx
+++ b/src/components/spaces/breeding/breeding-view.tsx
@@ -37,7 +37,7 @@ export class BreedingView extends BaseComponent<IProps, IState> {
     const { mother, father, litters, chartLabel, numOffspring, id } = activeBreedingPair;
     const numLitters = litters.length;
     const offspringClass = "offspring" + (numOffspring === 0 ? " hide" : "");
-    const showGametes = breeding.interactionMode === "gametes";
+    const showGametes = breeding.showingGametes;
     const { litterSliderVal } = this.state;
     const maxLitter = numLitters - 1;
     const sliderMax = this.getSliderMax(numLitters);
@@ -352,12 +352,12 @@ export class BreedingView extends BaseComponent<IProps, IState> {
     const { breeding } = this.stores;
     const { backpack } = this.stores;
     const inspecting = breeding.interactionMode === "inspect";
-    const showGametes = breeding.interactionMode === "gametes";
+    const showGametes = breeding.showingGametes;
     const selecting = breeding.interactionMode === "select";
     if (inspecting) {
       breeding.setInspectedMouse(mouse.id, pairId, litterIndex, isParent);
     } else if (showGametes) {
-      breeding.setInspectedGamete(mouse.id, pairId, litterIndex, isParent);
+      // breeding.setInspectedGamete(mouse.id, pairId, litterIndex, isParent);
     } else if (selecting && !backpack.cloneExists(mouse.id)) {
       const backpackMouse = BackpackMouse.create({
         species: mouse.species,

--- a/src/components/spaces/breeding/breeding-view.tsx
+++ b/src/components/spaces/breeding/breeding-view.tsx
@@ -356,8 +356,6 @@ export class BreedingView extends BaseComponent<IProps, IState> {
     const selecting = breeding.interactionMode === "select";
     if (inspecting) {
       breeding.setInspectedMouse(mouse.id, pairId, litterIndex, isParent);
-    } else if (showGametes) {
-      // breeding.setInspectedGamete(mouse.id, pairId, litterIndex, isParent);
     } else if (selecting && !backpack.cloneExists(mouse.id)) {
       const backpackMouse = BackpackMouse.create({
         species: mouse.species,

--- a/src/components/spaces/breeding/breeding-view.tsx
+++ b/src/components/spaces/breeding/breeding-view.tsx
@@ -86,7 +86,7 @@ export class BreedingView extends BaseComponent<IProps, IState> {
             />
           </div>
           { showGametes && <div className="gametes">
-              { this.renderGametes(parentGametes, parentGametePositions, parent === "mother") }
+            {this.renderGametes(parentGametes, parentGametePositions, parent === "mother", breeding.showParentGenotype)}
           </div> }
         </div>
       );
@@ -157,6 +157,7 @@ export class BreedingView extends BaseComponent<IProps, IState> {
                         const orgCollected = backpack.cloneExists(org.id);
                         const orgImages = [org.offspringImage];
                         if (orgCollected) orgImages.push(org.nestOutlineImage);
+                        const showGenotype = breeding.showOffspringGenotype && showGametes;
                         return (
                           <div
                             className="offspring-container"
@@ -185,7 +186,7 @@ export class BreedingView extends BaseComponent<IProps, IState> {
                                           && currentLitter === (litterNum - 1)}
                               showSex={breeding.showSexStack}
                               showHetero={breeding.showHeteroStack}
-                              showLabel={showGametes}
+                              showLabel={showGenotype}
                               isOffspring={true}
                             />
                           </div>
@@ -238,7 +239,7 @@ export class BreedingView extends BaseComponent<IProps, IState> {
     return sliderMax;
   }
 
-  private renderGametes = (gametes: string[], gametePositions: number[], mother: boolean) => {
+  private renderGametes = (gametes: string[], gametePositions: number[], mother: boolean, showGenotype: boolean) => {
     const gameteLabel = speciesDef(this.stores.unit).getGameteHTMLLabel;
     const parentIndex = mother ? 0 : 1;
     const iconClass = mother ? "icon egg " : "icon sperm ";
@@ -249,18 +250,21 @@ export class BreedingView extends BaseComponent<IProps, IState> {
         const gamete = gametes[position];
         const highlightMouse = offspringHightlightIndex === position;
         const highlightParent = parentHightlightIndex === parentIndex;
+        const className = "gamete" + (showGenotype ? "" : " no-label");
         const gameteViewClass = "hover-view " + (highlightMouse || highlightParent ? "show " : "")
                                 + (highlightMouse ? "tall" : "");
         const gameteIconClass = iconClass + (highlightMouse ? "highlight" : "");
         return(
-          <div className="gamete" key={i} style={{marginTop: offset}}
+          <div className={className} key={i} style={{marginTop: offset}}
                onMouseEnter={this.handleOffspringHoverEnter(position)}
                onMouseLeave={this.handleOffspringHoverExit}>
             <div className={gameteViewClass} />
             <div className={gameteIconClass} />
-            <div className="info-data" dangerouslySetInnerHTML={{
+            { showGenotype &&
+              <div className="info-data" dangerouslySetInnerHTML={{
                 __html: gameteLabel(gamete)
-            }} />
+              }} />
+            }
           </div>
         );
       })
@@ -352,7 +356,6 @@ export class BreedingView extends BaseComponent<IProps, IState> {
     const { breeding } = this.stores;
     const { backpack } = this.stores;
     const inspecting = breeding.interactionMode === "inspect";
-    const showGametes = breeding.showingGametes;
     const selecting = breeding.interactionMode === "select";
     if (inspecting) {
       breeding.setInspectedMouse(mouse.id, pairId, litterIndex, isParent);

--- a/src/components/spaces/populations-space.tsx
+++ b/src/components/spaces/populations-space.tsx
@@ -35,9 +35,9 @@ export class PopulationsSpaceComponent extends BaseComponent<IProps, IState> {
           return <InspectPanel
                   mouse1={populations.model.inspectedMouse}
                   pairLabel={""}
-                  isGamete={false}
+                  context="population"
+                  showGametes={false}
                   isOffspring={false}
-                  isPopulationInspect={true}
                   showGenotype={populations.model.showInspectGenotype}
                  />;
         default:

--- a/src/components/stacked-organism.pea.sass
+++ b/src/components/stacked-organism.pea.sass
@@ -8,5 +8,8 @@
     border-style: dashed
     transition-duration: 0s
 
-  .genotype-label.child-mouse
-    top: -2px
+  .genotype-label
+    &.child-mouse
+      top: -2px
+    &.parent-mouse
+      top: 74px

--- a/src/models/spaces/breeding/breeding.ts
+++ b/src/models/spaces/breeding/breeding.ts
@@ -317,11 +317,7 @@ export const BreedingModel = types
     },
 
     toggleInteractionMode(mode: "select" | "inspect" | "breed") {
-      if (self.interactionMode === mode) {
-        self.interactionMode = "none";
-      } else {
-        self.interactionMode = mode;
-      }
+      self.interactionMode = mode;
     },
 
     showGametes() {
@@ -347,6 +343,7 @@ export const BreedingModel = types
         });
         nestPair.setCurrentBreeding(true);
         self.rightPanel = "data";   // auto-switch to data when we go to breeding
+        self.interactionMode = "inspect";   // auto-switch to inspect mode
       }
     },
     setInspectedMouse(mouseId: string, pairId: string, litterIndex: number, isParent: boolean) {

--- a/src/models/spaces/breeding/breeding.ts
+++ b/src/models/spaces/breeding/breeding.ts
@@ -9,7 +9,7 @@ import { shuffle } from "lodash";
 import { speciesDef, units } from "../../units";
 import { Unit } from "../../../authoring";
 
-const BreedingInteractionModeEnum = types.enumeration("interaction", ["none", "breed", "select", "inspect", "gametes"]);
+const BreedingInteractionModeEnum = types.enumeration("interaction", ["none", "breed", "select", "inspect"]);
 export type BreedingInteractionModeType = typeof BreedingInteractionModeEnum.Type;
 
 export const EnvironmentColorTypeEnum = types.enumeration("environment", ["white", "neutral", "brown"]);
@@ -262,6 +262,7 @@ export const BreedingModel = types
     enableStudentControlOfMutations: false,
     chanceOfMutations: types.number,
     interactionMode: types.optional(BreedingInteractionModeEnum, "breed"),
+    showingGametes: false,
     backgroundType: types.optional(EnvironmentColorTypeEnum, "neutral"),
     nestPairs: types.array(NestPair),
     inspectInfo: InspectInfo,
@@ -315,13 +316,21 @@ export const BreedingModel = types
       self.breedWithMutations = value;
     },
 
-    toggleInteractionMode(mode: "select" | "inspect" | "breed" | "gametes") {
+    toggleInteractionMode(mode: "select" | "inspect" | "breed") {
       if (self.interactionMode === mode) {
         self.interactionMode = "none";
       } else {
         self.interactionMode = mode;
       }
     },
+
+    showGametes() {
+      self.showingGametes = true;
+    },
+    hideGametes() {
+      self.showingGametes = false;
+    },
+
     clearNestPairActiveBreeding() {
       self.nestPairs.forEach(pair => {
         pair.setCurrentBreeding(false);


### PR DESCRIPTION
This changes the logic of the gametes toggle switch. Previously, "showing gametes" was one of four different interactions
modes, which also included "breed" (selecting the nest), "select" and "inspect."

This was confusing, because "gametes" acted like "inspect", though it looked like its own independent toggle, and when users clicked to show gametes and then clicked on "inspect" they would leave "gametes" mode.

This disentangles the two, so that gametes being on or off is independent of the interaction mode.