### PR TITLE
Reverse pea genotype label

### DIFF
--- a/src/components/inspect-panel.tsx
+++ b/src/components/inspect-panel.tsx
@@ -113,19 +113,28 @@ export class InspectPanel extends BaseComponent<IProps, IState> {
 
   private renderGametePanel = (mouse: BackpackMouseType) => {
     const species = speciesDef(mouse.species);
+    const unitBreeding = units[mouse.species].breeding;
     const arrowImage = "assets/unit/mouse/breeding/inspect/inspect-arrow.png";
     const label1 = this.props.showParentGenotype ? mouse.genotype.slice(0, 1) : undefined;
     const label2 = this.props.showParentGenotype ? mouse.genotype.slice(-1) : undefined;
+    const motherGamete = (
+      <div className="gamete-panel-container">
+        <div className="gamete-panel-title">{species.inspectStrings.motherGameteLabel}</div>
+        { renderGameteIcon(mouse, "female", label1) }
+      </div>
+    );
+    const fatherGamete = (
+      <div className="gamete-panel-container">
+        <div className="gamete-panel-title">{species.inspectStrings.fatherGameteLabel}</div>
+        { renderGameteIcon(mouse, "male", label2) }
+      </div>
+    );
+    const leftGamete = unitBreeding.showMaleOnLeft ? fatherGamete : motherGamete;
+    const rightGamete = unitBreeding.showMaleOnLeft ? motherGamete : fatherGamete;
     return(
       <div className="gamete-panel">
-        <div className="gamete-panel-container">
-          <div className="gamete-panel-title">{species.inspectStrings.motherGameteLabel}</div>
-          { renderGameteIcon(mouse, "female", label1) }
-        </div>
-        <div className="gamete-panel-container">
-          <div className="gamete-panel-title">{species.inspectStrings.fatherGameteLabel}</div>
-          { renderGameteIcon(mouse, "male", label2) }
-        </div>
+        { leftGamete }
+        { rightGamete }
         <img src={arrowImage} className="arrow" />
       </div>
     );

--- a/src/models/units.ts
+++ b/src/models/units.ts
@@ -364,8 +364,8 @@ export const units: Units = {
       breedingPairs: [
         {
           parents: [
-            {genotype: "Rr", label: "Plant 1"},
-            {genotype: "Rr", label: "Plant 1"}
+            {genotype: "rR", label: "Plant 1"},
+            {genotype: "rR", label: "Plant 1"}
           ],
           label: "Experiment A",
           chartLabel: "Exp. A",
@@ -373,7 +373,7 @@ export const units: Units = {
         },
         {
           parents: [
-            {genotype: "Rr", label: "Plant 1"},
+            {genotype: "rR", label: "Plant 1"},
             {genotype: "RR", label: "Plant 2"}
           ],
           label: "Experiment B",
@@ -408,7 +408,7 @@ export const units: Units = {
         {
           parents: [
             {genotype: "rr", label: "Plant 3"},
-            {genotype: "Rr", label: "Plant 1"}
+            {genotype: "rR", label: "Plant 1"}
           ],
           label: "Experiment F",
           chartLabel: "Exp. F",

--- a/src/models/units.ts
+++ b/src/models/units.ts
@@ -319,7 +319,7 @@ export const units: Units = {
         },
         phenotypeHeading: "Pea shape",
         getPhenotypeLabel: (phenotype) => phenotype.charAt(0).toUpperCase() + phenotype.slice(1),
-        getGenotypeHTMLLabel: (genotype) => genotype,
+        getGenotypeHTMLLabel: (genotype) => genotype.charAt(1) + genotype.charAt(0),
         getGameteHTMLLabel: (allele) => allele,
         chartTypes: {
           phenotype: {legend: [

--- a/src/models/units.ts
+++ b/src/models/units.ts
@@ -337,8 +337,8 @@ export const units: Units = {
           let pieData = [];
           if (chartType === "genotype") {
             pieData = [{label: "RR", value: data.RR, color: colors.colorDataPeaDark},
-                       {label: "Rr", value: data.Rr, color: colors.colorDataPeaRound},
-                       {label: "rR", value: data.rR, color: colors.colorDataPeaRound},
+                       {label: "Rr", value: data.rR, color: colors.colorDataPeaRound},
+                       {label: "rR", value: data.Rr, color: colors.colorDataPeaRound},
                        {label: "rr", value: data.rr, color: colors.colorDataPeaWrinkled}];
           } else {
             pieData = [{label: "Round", value: data.round, color: colors.colorDataPeaRound},


### PR DESCRIPTION
This changes the standard genotype label so that the male allele is now show on the left.

This also swaps the gametes in the gamete-inspect panel such that the male gamete is on the left (matching the breeding panel).

Testable at

http://connected-bio-spaces.concord.org/branch/reverse-pea-genotype-label/index.html?%7B%22unit%22%3A%22pea%22%2C%22topBar%22%3Atrue%2C%22leftPanel%22%3Afalse%2C%22ui%22%3A%7B%22showBreedingSpace%22%3Atrue%2C%22investigationPanelSpace%22%3A%22breeding%22%7D%7D

(Breed some peas and turn on the gamete switch to show genotypes.)