### PR TITLE
Default to "mouse" if no species in BackpackMouse

### DIFF
--- a/src/models/backpack-mouse.ts
+++ b/src/models/backpack-mouse.ts
@@ -14,7 +14,7 @@ export const UNCOLLECTED_IMAGE = "assets/mouse_collect.png";
 
 export const BackpackMouse = types
   .model("Mouse", {
-    species: UnitTypeEnum,
+    species: types.optional(UnitTypeEnum, "mouse"),
     id: types.optional(types.identifier, () => uuid()),
     sex: SexTypeEnum,
     genotype: types.string,


### PR DESCRIPTION
Fixes issue in the following model:

[v 2.0.0](https://connected-bio-spaces.concord.org/version/2.0.0/?%7B%22curriculum%22%3A%22mouse%22%2C%22topBar%22%3Afalse%2C%22ui%22%3A%7B%22showPopulationSpace%22%3Atrue%2C%22showBreedingSpace%22%3Afalse%2C%22showOrganismSpace%22%3Atrue%2C%22showDNASpace%22%3Afalse%2C%22investigationPanelSpace%22%3A%22organism%22%7D%2C%22backpack%22%3A%7B%22collectedMice%22%3A%5B%7B%22sex%22%3A%22female%22%2C%22genotype%22%3A%22RR%22%7D%2C%7B%22sex%22%3A%22male%22%2C%22genotype%22%3A%22CC%22%7D%5D%7D%2C%22populations%22%3A%7B%22instructions%22%3A%22%22%2C%22environment%22%3A%22white%22%2C%22showSwitchEnvironmentsButton%22%3Atrue%2C%22includeNeutralEnvironment%22%3Atrue%2C%22initialPopulation%22%3A%7B%22white%22%3A50%2C%22tan%22%3A0%7D%2C%22numHawks%22%3A2%2C%22inheritance%22%3A%7B%22showStudentControlOfMutations%22%3Afalse%2C%22breedWithMutations%22%3Afalse%2C%22chanceOfMutations%22%3A2%2C%22showStudentControlOfInheritance%22%3Afalse%2C%22breedWithInheritance%22%3Atrue%2C%22randomOffspring%22%3A%7B%22white%22%3A33.33%2C%22tan%22%3A33.33%7D%7D%2C%22deadMice%22%3A%7B%22chanceOfShowingBody%22%3A50%2C%22timeToShowBody%22%3A50%7D%2C%22enableColorChart%22%3Atrue%2C%22enableGenotypeChart%22%3Atrue%2C%22enableAllelesChart%22%3Afalse%7D%2C%22organisms%22%3A%7B%22instructions%22%3A%221.%20Click%20Inspect%20and%20then%20click%20on%20a%20receptor%20protein%20in%20each%20mouse.%5Cn%5Cn2.%20In%20the%20Information%20panel%2C%20investigate%20the%20amino%20acid%20sequence%20by%20clicking%20on%20the%20folded%20protein%2C%20or%20using%20the%20slider%20under%20the%20sequence.%5Cn%5Cn3.%20Examine%20amino%20acids%2060%E2%80%9379.%20You%20can%20use%20the%20right%20and%20left%20arrows%20on%20your%20keyboard%20to%20move%20one%20amino%20acid%20at%20a%20time.%5Cn%5Cn4.%20Identify%20the%20amino%20acid%20that%20is%20different%20between%20the%20two%20receptors.%22%2C%22useMysteryOrganelles%22%3Afalse%2C%22useMysterySubstances%22%3Afalse%2C%22showZoomToReceptor%22%3Atrue%2C%22showZoomToNucleus%22%3Afalse%7D%2C%22breeding%22%3A%7B%22instructions%22%3A%22%22%2C%22enableInspectGametes%22%3Atrue%2C%22enableColorChart%22%3Atrue%2C%22enableGenotypeChart%22%3Atrue%2C%22enableSexChart%22%3Atrue%2C%22breedingType%22%3A%22litter%22%7D%7D)

[Fix](https://connected-bio-spaces.concord.org/branch/fix-backpack-mice/?%7B%22curriculum%22%3A%22mouse%22%2C%22topBar%22%3Afalse%2C%22ui%22%3A%7B%22showPopulationSpace%22%3Atrue%2C%22showBreedingSpace%22%3Afalse%2C%22showOrganismSpace%22%3Atrue%2C%22showDNASpace%22%3Afalse%2C%22investigationPanelSpace%22%3A%22organism%22%7D%2C%22backpack%22%3A%7B%22collectedMice%22%3A%5B%7B%22sex%22%3A%22female%22%2C%22genotype%22%3A%22RR%22%7D%2C%7B%22sex%22%3A%22male%22%2C%22genotype%22%3A%22CC%22%7D%5D%7D%2C%22populations%22%3A%7B%22instructions%22%3A%22%22%2C%22environment%22%3A%22white%22%2C%22showSwitchEnvironmentsButton%22%3Atrue%2C%22includeNeutralEnvironment%22%3Atrue%2C%22initialPopulation%22%3A%7B%22white%22%3A50%2C%22tan%22%3A0%7D%2C%22numHawks%22%3A2%2C%22inheritance%22%3A%7B%22showStudentControlOfMutations%22%3Afalse%2C%22breedWithMutations%22%3Afalse%2C%22chanceOfMutations%22%3A2%2C%22showStudentControlOfInheritance%22%3Afalse%2C%22breedWithInheritance%22%3Atrue%2C%22randomOffspring%22%3A%7B%22white%22%3A33.33%2C%22tan%22%3A33.33%7D%7D%2C%22deadMice%22%3A%7B%22chanceOfShowingBody%22%3A50%2C%22timeToShowBody%22%3A50%7D%2C%22enableColorChart%22%3Atrue%2C%22enableGenotypeChart%22%3Atrue%2C%22enableAllelesChart%22%3Afalse%7D%2C%22organisms%22%3A%7B%22instructions%22%3A%221.%20Click%20Inspect%20and%20then%20click%20on%20a%20receptor%20protein%20in%20each%20mouse.%5Cn%5Cn2.%20In%20the%20Information%20panel%2C%20investigate%20the%20amino%20acid%20sequence%20by%20clicking%20on%20the%20folded%20protein%2C%20or%20using%20the%20slider%20under%20the%20sequence.%5Cn%5Cn3.%20Examine%20amino%20acids%2060%E2%80%9379.%20You%20can%20use%20the%20right%20and%20left%20arrows%20on%20your%20keyboard%20to%20move%20one%20amino%20acid%20at%20a%20time.%5Cn%5Cn4.%20Identify%20the%20amino%20acid%20that%20is%20different%20between%20the%20two%20receptors.%22%2C%22useMysteryOrganelles%22%3Afalse%2C%22useMysterySubstances%22%3Afalse%2C%22showZoomToReceptor%22%3Atrue%2C%22showZoomToNucleus%22%3Afalse%7D%2C%22breeding%22%3A%7B%22instructions%22%3A%22%22%2C%22enableInspectGametes%22%3Atrue%2C%22enableColorChart%22%3Atrue%2C%22enableGenotypeChart%22%3Atrue%2C%22enableSexChart%22%3Atrue%2C%22breedingType%22%3A%22litter%22%7D%7D)