### PR TITLE
remove pip install awscli and invalidate call in s3_deploy.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ cache:
 # cf. https://stackoverflow.com/a/52387639
 install:
 - travis_retry gem install s3_website -v 3.4.0
-- travis_retry pip install awscli --upgrade --user
+#- travis_retry pip install awscli --upgrade --user
 - travis_retry npm ci
 - travis_retry cypress install
 script:

--- a/s3_deploy.sh
+++ b/s3_deploy.sh
@@ -56,4 +56,4 @@ s3_website push --site _site
 
 # explicit CloudFront invalidation to workaround s3_website gem invalidation bug
 # with origin path (https://github.com/laurilehmijoki/s3_website/issues/207).
-aws cloudfront create-invalidation --distribution-id $DISTRIBUTION_ID --paths $INVAL_PATH
+# aws cloudfront create-invalidation --distribution-id $DISTRIBUTION_ID --paths $INVAL_PATH


### PR DESCRIPTION
Remove pip install awscli and invalidate call in s3_deploy.sh to enable Travis builds (builds were failing).  Based on previous work in CLUE, GeoCode, and other projects:
https://github.com/concord-consortium/geocode/commit/ce24f88d550f9023c96be29a19c947bcf9c94afc