### PR TITLE
178222326 pea style improvements

### DIFF
--- a/src/components/spaces/breeding/breeding-data-nest-panel.pea.sass
+++ b/src/components/spaces/breeding/breeding-data-nest-panel.pea.sass
@@ -3,7 +3,7 @@
 .nesting-pair-data-panel.pea
   .pair-data
     .nest-display
-      height: 87px
+      height: 90px
       .mouse-holder
         display: flex
         justify-content: space-around
@@ -22,3 +22,6 @@
     .pair-data
       .right-mouse
         display: none
+
+  .pie-label
+    margin-top: -6px

--- a/src/components/spaces/breeding/breeding-data-nest-panel.sass
+++ b/src/components/spaces/breeding/breeding-data-nest-panel.sass
@@ -60,11 +60,16 @@
       position: absolute
       width: 65px
       transform: translateX(-47px) translateY(51px)
-      .secondary-images, .parent-genotypes
+      .secondary-images
         display: flex
         justify-content: space-around
         img
-          width: 16px
+          width: 14px
+      .parent-genotypes
+        display: flex
+        justify-content: space-around
+        font-size: 12px
+        font-weight: 400
     .pie-chart
       margin-right: 12px
     .empty-pie

--- a/src/components/spaces/breeding/breeding-view.sass
+++ b/src/components/spaces/breeding/breeding-view.sass
@@ -168,8 +168,8 @@
       font-weight: 500
     .total-offspring
       color: $color-nav-cinder-dark2
-      top: 155px
-      left: 5px
+      top: 137px
+      left: 6px
       font-size: 10px
       font-weight: 400
       line-height: 10px
@@ -182,20 +182,21 @@
       line-height: 10px
     .reset-button-container
       top: 190px
-      left: 5px
+      left: 9px
       .reset-button
-        font-size: 8px
-        background-color: $color-simdata-brick-light3
-        height: unset
-        width: unset
-        padding: 2px 6px 0
+        font-size: 10px
+        background-color: $color-simdata-brick-light2
+        height: 38px
+        width: 38px
+        padding: 3px 6px 0
         margin: 0
         border: 2px solid white
-        border-radius: 3px
+        border-radius: 7px
         &:hover
-          background-color: $color-simdata-brick-light2
-        &:active
           background-color: $color-simdata-brick-light1
+        &:active
+          background-color: $color-simdata-brick-dark1
+          color: white
         .icon
           width: 27px
           height: 20px
@@ -228,7 +229,7 @@
       position: absolute
       top: 2px
       left: 58px
-      width: 293px
+      width: 298px
       height: 218px
       z-index: 3
       pointer-events: none
@@ -239,7 +240,7 @@
       .focus-overlay-top
         height: 8px
       .focus-overlay-bottom
-        height: 114px
+        height: 110px
       .focus-window
         width: 303px
         height: 102px

--- a/src/components/spaces/breeding/breeding-view.sass
+++ b/src/components/spaces/breeding/breeding-view.sass
@@ -22,7 +22,7 @@
     .parent-label
       position: absolute
       top: 20px
-      left: 6px
+      left: 10px
 
     .gametes-box
       position: absolute

--- a/src/components/spaces/breeding/nest-pair.pea.sass
+++ b/src/components/spaces/breeding/nest-pair.pea.sass
@@ -71,9 +71,11 @@
         display: none
     .stacked-organism.pea
       .hetero-stack
-        transform: scaleX(0.7) scaleY(1.1)
-        border-radius: 25px
-        top: 12px
+        border-radius: 9px
+        top: 9px
+        height: 98px
+        width: 56px
+        border-width: 2px
 
   .pair-label
     opacity: 0.7

--- a/src/components/spaces/breeding/nest-pair.pea.sass
+++ b/src/components/spaces/breeding/nest-pair.pea.sass
@@ -45,7 +45,7 @@
     height: 110px
     width: 125px
     left: 23px
-    top: -16px
+    top: -10px
     opacity: 0
     border-radius: 15px
     transform: none

--- a/src/components/spaces/breeding/nest-pair.pea.sass
+++ b/src/components/spaces/breeding/nest-pair.pea.sass
@@ -80,8 +80,8 @@
   .pair-label
     opacity: 0.7
     width: 100px
-    left: 41px
-    top: 103px
+    left: 36px
+    top: 102px
     color: $color-black
     &.white
       color: $color-black

--- a/src/components/spaces/breeding/nest-pair.sass
+++ b/src/components/spaces/breeding/nest-pair.sass
@@ -80,7 +80,7 @@
   .nest-platform
     position: absolute
     top: 88px
-    width: 164px
+    width: 156px
 
   .mouse
     position: absolute

--- a/src/components/spaces/breeding/nest-pair.tsx
+++ b/src/components/spaces/breeding/nest-pair.tsx
@@ -79,6 +79,7 @@ export class NestPair extends BaseComponent<IProps, IState> {
             showSelection={this.props.showSelectionStack && !leftMouseCollected}
             showSex={this.props.showSexStack}
             showHetero={this.props.showHeteroStack}
+            ignoreHeteroStyleAdjustment={unit === "pea"}
           />
         </div>
         <div className={`mouse right ${positionClass}`} onClick={this.handleClickMouse(rightMouse)}>
@@ -90,6 +91,7 @@ export class NestPair extends BaseComponent<IProps, IState> {
             showSelection={this.props.showSelectionStack && !rightMouseCollected}
             showSex={this.props.showSexStack}
             showHetero={this.props.showHeteroStack}
+            ignoreHeteroStyleAdjustment={unit === "pea"}
           />
         </div>
         <div className={pairLabelClass}>{this.props.nestPair.label}</div>

--- a/src/components/spaces/breeding/nest-pair.tsx
+++ b/src/components/spaces/breeding/nest-pair.tsx
@@ -56,7 +56,7 @@ export class NestPair extends BaseComponent<IProps, IState> {
         { nestPlatformImage &&
           <img
             src={nestPlatformImage}
-            className={"nest-platform"}
+            className="nest-platform"
             data-test="nest-platform-image"
           />
         }

--- a/src/components/spaces/breeding/nest-pair.tsx
+++ b/src/components/spaces/breeding/nest-pair.tsx
@@ -53,7 +53,6 @@ export class NestPair extends BaseComponent<IProps, IState> {
 
     return(
       <div className={`${nestClass} ${unit}`} onClick={this.handleClickNest}>
-        <div className={nestInspectClass} />
         { nestPlatformImage &&
           <img
             src={nestPlatformImage}
@@ -61,6 +60,7 @@ export class NestPair extends BaseComponent<IProps, IState> {
             data-test="nest-platform-image"
           />
         }
+        <div className={nestInspectClass} />
         { nestHoverImage &&
           <img
             src={nestHoverImage}

--- a/src/components/stacked-organism.pea.sass
+++ b/src/components/stacked-organism.pea.sass
@@ -5,7 +5,7 @@
     height: 80%
 
   .hetero-stack
-    border-style: dashed
+    border-style: dotted
     transition-duration: 0s
 
   .genotype-label

--- a/src/components/stacked-organism.tsx
+++ b/src/components/stacked-organism.tsx
@@ -16,51 +16,55 @@ interface IProps {
   showHetero: boolean;
   showLabel?: boolean;
   isOffspring?: boolean;
+  ignoreHeteroStyleAdjustment?: boolean;
 }
 
 const path = "assets/unit/mouse/populations/";
 const selectionImage =  path + "select-stack.png";
 
 export const StackedOrganism: React.SFC<IProps> = (props) => {
-  const selectionClass = "selection-stack " + (props.showSelection ? "show" : "");
-  const gameteViewClass = "gamete-view-stack " + (props.showGameteSelection ? "show" : "");
+  const { organism, organismImages, height, flipped, showSelection, showGameteSelection, showInspect, showSex,
+    showHetero, showLabel, isOffspring, ignoreHeteroStyleAdjustment } = props;
+  const selectionClass = "selection-stack " + (showSelection ? "show" : "");
+  const gameteViewClass = "gamete-view-stack " + (showGameteSelection ? "show" : "");
   const inspectClass = "inspect-stack";
-  const heteroClass = "hetero-stack " + ((props.showHetero && props.organism.isHeterozygote) ? "show" : "");
-  const sexClass = "sex-stack " + props.organism.sex + (props.showSex ? " show" : "");
-  const imgClasses = "organism-image " + (props.flipped ? "flip" : "");
-  const species = speciesDef(props.organism.species);
-  const label = species.getGenotypeHTMLLabel(props.organism.genotype);
-  const labelClass = "genotype-label " + (props.isOffspring ? "child-mouse" : "parent-mouse");
+  const heteroClass = "hetero-stack " + ((showHetero && organism.isHeterozygote) ? "show" : "");
+  const sexClass = "sex-stack " + organism.sex + (showSex ? " show" : "");
+  const imgClasses = "organism-image " + (flipped ? "flip" : "");
+  const species = speciesDef(organism.species);
+  const label = species.getGenotypeHTMLLabel(organism.genotype);
+  const labelClass = "genotype-label " + (isOffspring ? "child-mouse" : "parent-mouse");
   // sizes defined here instead of in css so we can base width and left dimension off height dimension
-  const fullSize = {
-    height: props.height,
-    width: props.height
-  };
+  const fullSize = { height, width: height };
 
   const normalHeight = 150;
   const normalBorderWidth = 4;
   const sexSize = {
-    height: props.height * .9,
-    width: props.height * .9,
-    borderWidth: (normalBorderWidth * props.height / normalHeight)
+    height: height * .9,
+    width: height * .9,
+    borderWidth: (normalBorderWidth * height / normalHeight)
   };
-  const heteroSize = {
-    height: props.height * .78,
-    width: props.height * .78,
-    borderWidth: (normalBorderWidth * props.height / normalHeight)
-  };
+  const heteroSize = ignoreHeteroStyleAdjustment
+    ? undefined
+    : {
+        height: height * .78,
+        width: height * .78,
+        borderWidth: (normalBorderWidth * height / normalHeight)
+      };
 
   return (
-    <div className={`stacked-organism ${props.organism.species}`} style={fullSize}>
-      { props.showGameteSelection && <div className={gameteViewClass} style={fullSize} data-test="gamete-view" /> }
-      { props.showInspect && <div className={inspectClass} style={fullSize} data-test="inspect-view" /> }
-      { props.showLabel && <div className={labelClass} dangerouslySetInnerHTML={{ __html: label }}/> }
+    <div className={`stacked-organism ${organism.species}`} style={fullSize}>
+      { showGameteSelection && <div className={gameteViewClass} style={fullSize} data-test="gamete-view" /> }
+      { showInspect && <div className={inspectClass} style={fullSize} data-test="inspect-view" /> }
+      { showLabel && <div className={labelClass} dangerouslySetInnerHTML={{ __html: label }}/> }
       <img src={selectionImage} className={selectionClass} style={fullSize} data-test="selection-image" />
-      {
-        props.organismImages.map((image, i) =>
-          <img src={image} className={imgClasses}
-            key={`org-image-${i}`} data-test={`org-image-${i}`} />
-        )
+      { organismImages.map((image, i) =>
+          <img
+            src={image}
+            className={imgClasses}
+            key={`org-image-${i}`}
+            data-test={`org-image-${i}`}
+          />)
       }
       <div className={sexClass} style={sexSize}/>
       <div className={heteroClass} style={heteroSize}/>

--- a/src/models/units.ts
+++ b/src/models/units.ts
@@ -318,7 +318,7 @@ export const units: Units = {
               return "round";
           }
         },
-        phenotypeHeading: "Pea shape",
+        phenotypeHeading: "Pea Shape",
         getPhenotypeLabel: (phenotype) => phenotype.charAt(0).toUpperCase() + phenotype.slice(1),
         getGenotypeHTMLLabel: (genotype) => genotype.charAt(1) + genotype.charAt(0),
         getGameteHTMLLabel: (allele) => allele,


### PR DESCRIPTION
This is a series of small improvements to bring the pea unit display more in line with the UI spec.  Changes include:
- improve the heterozygote selection display
- fix the greenhouse inspect highlight position and z-order
- fix position of breeding label position
- Improve total offspring label position, offspring pen border, and reset button style
- Update pea data panel box size, genotype font and position
- Fix text case on data graph button
- Improve shelf and shelf label positions and sizing