### PR TITLE
Improve inspect/collect/gamete cursor states and highlight circles

### DIFF
--- a/src/components/spaces/breeding/breeding-container.tsx
+++ b/src/components/spaces/breeding/breeding-container.tsx
@@ -51,10 +51,10 @@ export class BreedingContainer extends BaseComponent<IProps, IState> {
     const inspectButtonClass = (breeding.interactionMode === "inspect" ? "sticky" : "sticky-off");
     const collectButtonClass = (breeding.interactionMode === "select" ? "sticky-alt" : "sticky-alt-off");
     const containerClass = "breeding-container"
-                    + (breeding.interactionMode === "inspect" ? " inspect" : "")
-                    + (breeding.interactionMode === "select" ? " select" : "")
-                    + ((breeding.interactionMode === "breed" && showingNesting) ? " breed" : "")
-                    + ((breeding.showGametes && !showingNesting) ? " gametes" : "");
+      + (breeding.interactionMode === "inspect" ? " inspect" : "")
+      + (breeding.interactionMode === "select" ? " select" : "")
+      + ((breeding.interactionMode === "breed" && showingNesting) ? " breed" : "")
+      + ((breeding.showingGametes && !showingNesting && breeding.interactionMode === "inspect") ? " gametes" : "");
 
     const mainComponent = showingNesting ? <NestingView /> : <BreedingView />;
     const switchLevelsButtonLabel = showingNesting ? "Breeding" : breedingUnit.nestButtonTitle;

--- a/src/components/stacked-organism.sass
+++ b/src/components/stacked-organism.sass
@@ -8,7 +8,7 @@
 
   &:hover .selection-stack.show
     opacity: 1
-  &:hover .gamete-view-stack
+  &:hover .gamete-view-stack.show
     opacity: .75
   &:hover .inspect-stack
     opacity: .75
@@ -58,8 +58,6 @@
     opacity: 0
     transition-duration: .25s
     background-color: $color-nav-shamrock-light1
-    &.show
-      opacity: .75
   .inspect-stack
     position: absolute
     top: 0

--- a/src/components/stacked-organism.tsx
+++ b/src/components/stacked-organism.tsx
@@ -26,7 +26,7 @@ export const StackedOrganism: React.SFC<IProps> = (props) => {
   const { organism, organismImages, height, flipped, showSelection, showGameteSelection, showInspect, showSex,
     showHetero, showLabel, isOffspring, ignoreHeteroStyleAdjustment } = props;
   const selectionClass = "selection-stack " + (showSelection ? "show" : "");
-  const gameteViewClass = "gamete-view-stack " + (showGameteSelection ? "show" : "");
+  const gameteViewClass = "gamete-view-stack " + ((showGameteSelection && !showSelection) ? "show" : "");
   const inspectClass = "inspect-stack";
   const heteroClass = "hetero-stack " + ((showHetero && organism.isHeterozygote) ? "show" : "");
   const sexClass = "sex-stack " + organism.sex + (showSex ? " show" : "");
@@ -55,9 +55,10 @@ export const StackedOrganism: React.SFC<IProps> = (props) => {
   return (
     <div className={`stacked-organism ${organism.species}`} style={fullSize}>
       { showGameteSelection && <div className={gameteViewClass} style={fullSize} data-test="gamete-view" /> }
-      { showInspect && <div className={inspectClass} style={fullSize} data-test="inspect-view" /> }
-      { showLabel && <div className={labelClass} dangerouslySetInnerHTML={{ __html: label }}/> }
+      { (showInspect && !showGameteSelection) &&
+        <div className={inspectClass} style={fullSize} data-test="inspect-view" /> }
       <img src={selectionImage} className={selectionClass} style={fullSize} data-test="selection-image" />
+      { showLabel && <div className={labelClass} dangerouslySetInnerHTML={{ __html: label }}/> }
       { organismImages.map((image, i) =>
           <img
             src={image}


### PR DESCRIPTION
This PR makes minor improvements to the cursor and organism highlight in relation to the show/hide gamete (based on discussion with Michael):
- collect cursor is shown when collect button is active (regardless of state of show/hide gametes)
- if inspect is active and we are hiding gametes, red inspect cursor is shown
- if inspect is active and we are showing gametes, organism highlight is green circle
- if inspect is active and we are hiding gametes, organism highlight is red circle
- if collect is active and either show or hide gametes is active, organism highlight is blue circle